### PR TITLE
feat: show thumbnails for recent posts

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -123,24 +123,27 @@ function Dashboard() {
       // Fetch different post types in parallel
       const [publishedData, draftData, scheduledData] = await Promise.all([
         // Published posts
-        BloggerService.getPosts(blogId, { 
+        BloggerService.getPosts(blogId, {
           status: 'live',
           maxResults: 10,
-          fetchBodies: false
+          fetchBodies: false,
+          fetchImages: true
         }),
         
         // Draft posts
         BloggerService.getPosts(blogId, {
           status: 'draft',
           maxResults: 10,
-          fetchBodies: false
+          fetchBodies: false,
+          fetchImages: true
         }),
         
         // Scheduled posts
         BloggerService.getPosts(blogId, {
           status: 'scheduled',
           maxResults: 10,
-          fetchBodies: false
+          fetchBodies: false,
+          fetchImages: true
         })
       ]);
       
@@ -569,6 +572,16 @@ function Dashboard() {
                   <div className="posts-list">
                     {posts.map(post => (
                       <div key={post.id} className="post-item">
+                        {post.images && post.images.length > 0 ? (
+                          <img
+                            src={post.images[0].url}
+                            alt={post.title}
+                            className="post-thumbnail"
+                          />
+                        ) : (
+                          <div className="post-thumbnail no-image" />
+                        )}
+
                         <div className="post-info">
                           <h3>{post.title}</h3>
                           <div className="post-meta">

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -184,8 +184,8 @@
   
   .post-item {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 20px;
     padding: 20px;
     border-radius: 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -203,6 +203,26 @@
   .post-item:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .post-thumbnail {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 4px;
+    background-color: #f0f0f0;
+  }
+
+  .dark .post-thumbnail {
+    background-color: #444;
+  }
+
+  .post-thumbnail.no-image {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+    font-size: 0.75rem;
   }
   
   .post-info {
@@ -348,6 +368,12 @@
     .post-item {
       flex-direction: column;
       align-items: flex-start;
+    }
+
+    .post-thumbnail {
+      width: 100%;
+      height: auto;
+      max-height: 200px;
     }
     
     .post-actions {


### PR DESCRIPTION
## Summary
- fetch thumbnail image data when loading blog posts
- render first post image as thumbnail in recent posts list
- style post list to display thumbnail cleanly and responsively

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d28aa2d308324b6e2050feab00c40