### PR TITLE
feat: add ordering controls for recent posts

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -20,6 +20,7 @@ function Dashboard() {
   const [selectedBlog, setSelectedBlog] = useState(null);
   const [posts, setPosts] = useState([]);
   const [sortBy, setSortBy] = useState('date');
+  const [sortOrder, setSortOrder] = useState('desc');
   const [statusFilter, setStatusFilter] = useState('ALL');
   const [stats, setStats] = useState({
     totalPosts: 0,
@@ -383,14 +384,16 @@ function Dashboard() {
 
     return [...filtered].sort((a, b) => {
       if (sortBy === 'title') {
-        return a.title.localeCompare(b.title);
+        return sortOrder === 'asc'
+          ? a.title.localeCompare(b.title)
+          : b.title.localeCompare(a.title);
       }
 
       const dateA = new Date(a.published || a.scheduled || a.updated || 0);
       const dateB = new Date(b.published || b.scheduled || b.updated || 0);
-      return dateB - dateA;
+      return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
     });
-  }, [posts, sortBy, statusFilter]);
+  }, [posts, sortBy, statusFilter, sortOrder]);
 
   /**
    * Retry loading blogs after error
@@ -588,6 +591,16 @@ function Dashboard() {
                         <option value="date">Data</option>
                         <option value="title">Título</option>
                       </select>
+                      <button
+                        type="button"
+                        className="order-toggle"
+                        onClick={() =>
+                          setSortOrder(prev => (prev === 'asc' ? 'desc' : 'asc'))
+                        }
+                        title="Inverter ordem"
+                      >
+                        {sortOrder === 'asc' ? '↑' : '↓'}
+                      </button>
                     </div>
                     <div className="filter-control">
                       <label>Filtrar:</label>

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -158,7 +158,20 @@
   .dark .posts-section h2 {
     border-color: var(--border-dark);
   }
-  
+
+  .posts-controls {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .posts-controls label {
+    margin-right: 8px;
+    font-weight: 500;
+  }
+
   .no-posts {
     padding: 40px;
     text-align: center;

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -177,12 +177,23 @@
     align-items: center;
   }
 
+  .posts-controls .filter-control,
+  .posts-controls .tag-filter-control {
+    display: flex;
+    align-items: center;
+  }
+
   .posts-controls .order-toggle {
     margin-left: 8px;
     background: none;
     border: none;
     cursor: pointer;
     font-size: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 8px;
+    height: 32px;
   }
 
   .posts-controls .order-toggle:hover {

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -172,6 +172,23 @@
     font-weight: 500;
   }
 
+  .posts-controls .sort-control {
+    display: flex;
+    align-items: center;
+  }
+
+  .posts-controls .order-toggle {
+    margin-left: 8px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+
+  .posts-controls .order-toggle:hover {
+    opacity: 0.8;
+  }
+
   .no-posts {
     padding: 40px;
     text-align: center;


### PR DESCRIPTION
## Summary
- add sorting and status filtering options to Dashboard's recent posts list
- style ordering controls

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689d285023a483249714182a27df0f36