### PR TITLE
feat: add debugger toggle in settings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,11 @@ function App() {
     return savedTheme || 'dark'; // Default to dark theme
   });
 
+  const [showDebugger, setShowDebugger] = useState(() => {
+    const savedSettings = JSON.parse(localStorage.getItem('blogcraft_settings') || '{}');
+    return savedSettings.showDebugger || false;
+  });
+
   // Tracking authentication state
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
@@ -60,22 +65,33 @@ function App() {
       const validated = token && !AuthService.isTokenExpired();
       setIsAuthenticated(validated);
     };
-    
+
+    const updateDebugger = () => {
+      const savedSettings = JSON.parse(localStorage.getItem('blogcraft_settings') || '{}');
+      setShowDebugger(savedSettings.showDebugger || false);
+    };
+
     // Check immediately
     checkAuth();
-    
+    updateDebugger();
+
     // Setup localStorage event listener to detect changes
     const handleStorageChange = (e) => {
       if (e.key === 'blogcraft_token') {
         checkAuth();
       }
+      if (e.key === 'blogcraft_settings') {
+        updateDebugger();
+      }
     };
-    
+
     window.addEventListener('storage', handleStorageChange);
-    
+    window.addEventListener('blogcraft_settings_updated', updateDebugger);
+
     // Cleanup
     return () => {
       window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('blogcraft_settings_updated', updateDebugger);
     };
   }, []);
 
@@ -100,8 +116,8 @@ function App() {
     <BrowserRouter>
       <div className={`app-container ${theme}`}>
 
-        {/* Add the debugger here, before Routes */}
-        {process.env.NODE_ENV !== 'production' && <LoginDebugger />}
+          {/* Add the debugger here, before Routes */}
+          {process.env.NODE_ENV !== 'production' && showDebugger && <LoginDebugger />}
         
 
         <Routes>

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -28,7 +28,8 @@ function Settings({ theme, toggleTheme }) {
     autoSaveInterval: 5,
     autoBackup: true,
     confirmBeforeDelete: true,
-    defaultPublishStatus: 'draft'
+    defaultPublishStatus: 'draft',
+    showDebugger: false
   });
   const [error, setError] = useState(null);
   
@@ -52,7 +53,8 @@ function Settings({ theme, toggleTheme }) {
         autoSaveInterval: savedSettings.autoSaveInterval || 5,
         autoBackup: savedSettings.autoBackup !== undefined ? savedSettings.autoBackup : true,
         confirmBeforeDelete: savedSettings.confirmBeforeDelete !== undefined ? savedSettings.confirmBeforeDelete : true,
-        defaultPublishStatus: savedSettings.defaultPublishStatus || 'draft'
+        defaultPublishStatus: savedSettings.defaultPublishStatus || 'draft',
+        showDebugger: savedSettings.showDebugger !== undefined ? savedSettings.showDebugger : false
       });
     } catch (error) {
       console.error('Erro ao carregar configurações:', error);
@@ -97,9 +99,9 @@ function Settings({ theme, toggleTheme }) {
    * Atualiza uma configuração
    */
   const handleSettingChange = (e, setting) => {
-    const value = 
-      setting === 'autoBackup' || setting === 'confirmBeforeDelete'
-        ? e.target.checked 
+    const value =
+      setting === 'autoBackup' || setting === 'confirmBeforeDelete' || setting === 'showDebugger'
+        ? e.target.checked
         : setting === 'autoSaveInterval'
           ? parseInt(e.target.value, 10)
           : e.target.value;
@@ -125,10 +127,13 @@ function Settings({ theme, toggleTheme }) {
     try {
       // Salvar configurações gerais
       localStorage.setItem('blogcraft_settings', JSON.stringify(settings));
-      
+
       // Salvar idioma
       i18n.setLocale(language);
-      
+
+      // Notify application about settings update
+      window.dispatchEvent(new Event('blogcraft_settings_updated'));
+
       alert(t('settings.confirmations.saveSuccess'));
     } catch (error) {
       console.error('Erro ao salvar configurações:', error);
@@ -147,11 +152,13 @@ function Settings({ theme, toggleTheme }) {
         autoSaveInterval: 5,
         autoBackup: true,
         confirmBeforeDelete: true,
-        defaultPublishStatus: 'draft'
+        defaultPublishStatus: 'draft',
+        showDebugger: false
       };
-      
+
       setSettings(defaultSettings);
       localStorage.setItem('blogcraft_settings', JSON.stringify(defaultSettings));
+      window.dispatchEvent(new Event('blogcraft_settings_updated'));
       alert(t('settings.confirmations.resetSuccess'));
     }
   };
@@ -329,15 +336,30 @@ function Settings({ theme, toggleTheme }) {
                 <p className="setting-description">{t('settings.fields.languageDesc')}</p>
               </div>
             </div>
-            
+            <div className="setting-group">
+              <h2>{t('settings.sections.debug')}</h2>
+
+              <div className="setting-item">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={settings.showDebugger}
+                    onChange={(e) => handleSettingChange(e, 'showDebugger')}
+                  />
+                  {t('settings.fields.showDebugger')}
+                </label>
+                <p className="setting-description">{t('settings.fields.showDebuggerDesc')}</p>
+              </div>
+            </div>
+
             <div className="setting-group">
               <h2>{t('settings.sections.dataManagement')}</h2>
-              
+
               <div className="data-actions">
                 <button className="reset-settings-button" onClick={handleResetSettings}>
                   {t('settings.buttons.reset')}
                 </button>
-                
+
                 <button className="clear-data-button" onClick={handleClearData}>
                   {t('settings.buttons.clearData')}
                 </button>

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -164,11 +164,12 @@ const translations = {
         general: 'General Preferences',
         autoSave: 'Auto-Save',
         security: 'Security',
-        appearance: 'Appearance',
-        api: 'API Settings',
-        dataManagement: 'Data Management'
-      },
-      fields: {
+          appearance: 'Appearance',
+          api: 'API Settings',
+          dataManagement: 'Data Management',
+          debug: 'Debugging'
+        },
+        fields: {
         defaultBlog: 'Default Blog:',
         defaultBlogDesc: 'Blog selected by default when creating a new post.',
         defaultTemplate: 'Default Template:',
@@ -190,8 +191,10 @@ const translations = {
         customClientId: 'Use custom Client ID',
         customClientIdDesc: 'Enable this option to use a custom Google Client ID instead of the default one.',
         clientId: 'Google Client ID:',
-        clientIdDesc: 'Enter the Client ID obtained from Google Cloud Console.'
-      },
+        clientIdDesc: 'Enter the Client ID obtained from Google Cloud Console.',
+        showDebugger: 'Show Debugger Window',
+        showDebuggerDesc: 'Display authentication debugger overlay.'
+        },
       buttons: {
         save: 'Save Settings',
         reset: 'Restore Default Settings',

--- a/src/locales/pt-PT.js
+++ b/src/locales/pt-PT.js
@@ -164,11 +164,12 @@ const translations = {
         general: 'Preferências Gerais',
         autoSave: 'Guardamento Automático',
         security: 'Segurança',
-        appearance: 'Aparência',
-        api: 'Configurações de API',
-        dataManagement: 'Gestão de Dados'
-      },
-      fields: {
+          appearance: 'Aparência',
+          api: 'Configurações de API',
+          dataManagement: 'Gestão de Dados',
+          debug: 'Depuração'
+        },
+        fields: {
         defaultBlog: 'Blogue Predefinido:',
         defaultBlogDesc: 'Blogue selecionado por predefinição ao criar um novo artigo.',
         defaultTemplate: 'Modelo Predefinido:',
@@ -190,8 +191,10 @@ const translations = {
         customClientId: 'Usar ID de Cliente personalizado',
         customClientIdDesc: 'Ative esta opção para usar um ID de Cliente do Google personalizado em vez do predefinido.',
         clientId: 'ID de Cliente do Google:',
-        clientIdDesc: 'Insira o ID de Cliente obtido na Google Cloud Console.'
-      },
+        clientIdDesc: 'Insira o ID de Cliente obtido na Google Cloud Console.',
+        showDebugger: 'Mostrar janela de depuração',
+        showDebuggerDesc: 'Exibe a janela de depuração de autenticação.'
+        },
       buttons: {
         save: 'Guardar Definições',
         reset: 'Restaurar Definições Predefinidas',


### PR DESCRIPTION
## Summary
- allow enabling debugger window from settings
- persist debugger toggle in saved settings
- update translations for new debug setting

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689e9175485483248bc0a98ef63a4723