### PR TITLE
Add background scheduler service for offline publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+scheduled-posts.json

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ npm test
 
 The production build will be created in `build/`.
 
+## 🕒 Background Scheduler Service
+
+BlogCraft includes an optional Node.js scheduler that can publish posts at a later time even when the main UI is closed.
+
+1. Add scheduled posts to `scheduled-posts.json` (see `scheduled-posts.example.json` for the structure).
+2. Export a Blogger access token in `BLOGGER_TOKEN` and optionally set `SCHEDULED_POSTS_FILE`.
+3. Run the service:
+   ```bash
+   npm run scheduler
+   ```
+The process will stay running and publish each post at its configured `publishDate`.
+
 ## 📚 More Help
 - [Blogger API Documentation](https://developers.google.com/blogger/docs/3.0/getting_started)
 - [Google OAuth Guide](https://developers.google.com/identity/protocols/oauth2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ckeditor/ckeditor5-react": "^5.0.6",
         "@react-oauth/google": "^0.12.1",
         "file-saver": "^2.0.5",
+        "node-schedule": "^2.1.1",
         "react": "^18.2.0",
         "react-datetime-picker": "^5.5.0",
         "react-dom": "^18.2.0",
@@ -6543,6 +6544,18 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
@@ -12435,6 +12448,12 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
+    "node_modules/long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12463,6 +12482,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -13161,6 +13189,20 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
+    },
+    "node_modules/node-schedule": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.2.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -17967,6 +18009,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+      "license": "MIT"
     },
     "node_modules/source-list-map": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "start": "set NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
     "build": "set NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
     "test": "set NODE_OPTIONS=--openssl-legacy-provider && react-scripts test",
-    "eject": "set NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject"
+    "eject": "set NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject",
+    "scheduler": "node scheduler.js"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^35.4.0",
     "@ckeditor/ckeditor5-react": "^5.0.6",
     "@react-oauth/google": "^0.12.1",
     "file-saver": "^2.0.5",
+    "node-schedule": "^2.1.1",
     "react": "^18.2.0",
     "react-datetime-picker": "^5.5.0",
     "react-dom": "^18.2.0",

--- a/scheduled-posts.example.json
+++ b/scheduled-posts.example.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "POST_ID",
+    "blogId": "BLOG_ID",
+    "publishDate": "2024-06-01T10:00:00Z"
+  }
+]

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const schedule = require('node-schedule');
+
+// File containing posts to be scheduled. Each entry:
+// {"id": "postId", "blogId": "blogId", "publishDate": "2024-06-01T10:00:00Z"}
+const postsFile = process.env.SCHEDULED_POSTS_FILE || path.join(__dirname, 'scheduled-posts.json');
+
+// OAuth token to access Blogger API
+const token = process.env.BLOGGER_TOKEN;
+
+if (!token) {
+  console.error('Missing BLOGGER_TOKEN environment variable.');
+  process.exit(1);
+}
+
+let posts = [];
+try {
+  const data = fs.readFileSync(postsFile, 'utf-8');
+  posts = JSON.parse(data);
+} catch (err) {
+  console.error('Failed to load scheduled posts file:', postsFile, err);
+  process.exit(1);
+}
+
+posts.forEach(post => {
+  const publishDate = new Date(post.publishDate);
+  if (isNaN(publishDate)) {
+    console.error('Invalid publishDate for post', post);
+    return;
+  }
+
+  schedule.scheduleJob(publishDate, async () => {
+    try {
+      const baseUrl = `https://www.googleapis.com/blogger/v3/blogs/${post.blogId}/posts/${post.id}/publish`;
+      const url = `${baseUrl}?publishDate=${encodeURIComponent(publishDate.toISOString())}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      if (!res.ok) {
+        console.error('Failed to publish post', post.id, await res.text());
+      } else {
+        console.log('Published post', post.id, 'at', new Date().toISOString());
+      }
+    } catch (error) {
+      console.error('Error publishing post', post.id, error);
+    }
+  });
+});
+
+console.log(`Scheduled ${posts.length} posts. Scheduler running...`);


### PR DESCRIPTION
## Summary
- add Node-based scheduler to publish posts when the UI is offline
- expose `npm run scheduler` and document usage
- ignore local schedule files

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689e9234bb78832490bed07286824fcd