### PR TITLE
Improve stats bar readability

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -218,7 +218,7 @@ function Dashboard() {
     for (let i = 5; i >= 0; i--) {
       const month = new Date(now.getFullYear(), now.getMonth() - i, 1);
       last6Months.push({
-        label: month.toLocaleDateString('pt-BR', { month: 'short', year: 'numeric' }),
+        label: `${month.toLocaleString(i18n.getLocale(), { month: 'short' })} ${month.getFullYear()}`,
         count: 0,
         month: month.getMonth(),
         year: month.getFullYear()

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -104,17 +104,17 @@
   
   .month-chart {
     display: flex;
-    justify-content: space-between;
     align-items: flex-end;
     height: 120px;
     margin-top: 20px;
+    gap: 10px;
   }
-  
+
   .month-bar {
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;
+    flex: 1;
   }
   
   .bar {
@@ -136,8 +136,6 @@
     margin-top: 10px;
     font-size: 0.8rem;
     white-space: nowrap;
-    transform: rotate(-45deg);
-    transform-origin: top left;
   }
   
   .posts-section {


### PR DESCRIPTION
## Summary
- refine month label generation to avoid locale connectors
- simplify stats chart layout and show labels horizontally

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689facc5e5a08324a8ee5d18e1d2241e