### PR TITLE
Translate remaining Portuguese strings

### DIFF
--- a/src/components/PostEditor.js
+++ b/src/components/PostEditor.js
@@ -142,7 +142,7 @@ function PostEditor({ theme, toggleTheme }) {
     
     setFeedback({
       type: 'info',
-      message: `Rascunho salvo automaticamente às ${new Date().toLocaleTimeString()}`,
+      message: t('editor.saving.autoSave', { time: new Date().toLocaleTimeString() }),
       duration: 3000
     });
   };
@@ -174,20 +174,20 @@ function PostEditor({ theme, toggleTheme }) {
       }
     } catch (error) {
       console.error('Erro ao buscar blogs:', error);
-      
+
       // Se for erro de autenticação, redirecionar para login
-      if (error.message.includes('autenticação') || 
-          error.message.includes('login') || 
+      if (error.message.includes('autenticação') ||
+          error.message.includes('login') ||
           error.message.includes('token')) {
-        
+
         AuthService.removeAuthToken();
         navigate('/', { replace: true });
         return;
       }
-      
+
       setFeedback({
         type: 'error',
-        message: 'Não foi possível carregar seus blogs. Por favor, verifique sua conexão e tente novamente.'
+        message: t('editor.errors.loadBlogs')
       });
     } finally {
       setLoading(false);
@@ -224,20 +224,20 @@ function PostEditor({ theme, toggleTheme }) {
       });
     } catch (error) {
       console.error('Erro ao buscar post:', error);
-      
+
       // Se for erro de autenticação, redirecionar para login
-      if (error.message.includes('autenticação') || 
-          error.message.includes('login') || 
+      if (error.message.includes('autenticação') ||
+          error.message.includes('login') ||
           error.message.includes('token')) {
-        
+
         AuthService.removeAuthToken();
         navigate('/', { replace: true });
         return;
       }
-      
+
       setFeedback({
         type: 'error',
-        message: 'Não foi possível carregar o post. Por favor, verifique sua conexão e tente novamente.'
+        message: t('editor.errors.loadPost')
       });
     } finally {
       setLoading(false);
@@ -322,7 +322,7 @@ function PostEditor({ theme, toggleTheme }) {
    * Salva o conteúdo atual como template
    */
   const handleSaveTemplate = () => {
-    const templateName = prompt('Nome do template:');
+    const templateName = prompt(t('editor.templates.templateName'));
     
     if (!templateName) return;
     
@@ -339,7 +339,7 @@ function PostEditor({ theme, toggleTheme }) {
     
     setFeedback({
       type: 'success',
-      message: 'Template salvo com sucesso!',
+      message: t('templates.notifications.saved'),
       duration: 3000
     });
   };
@@ -402,7 +402,7 @@ function PostEditor({ theme, toggleTheme }) {
     if (!selectedBlog) {
       setFeedback({
         type: 'error',
-        message: 'Por favor, selecione um blog antes de salvar o post.'
+        message: t('editor.errors.selectBlog')
       });
       return;
     }
@@ -410,7 +410,7 @@ function PostEditor({ theme, toggleTheme }) {
     if (!postData.title.trim()) {
       setFeedback({
         type: 'error',
-        message: 'Por favor, insira um título para o post.'
+        message: t('editor.errors.enterTitle')
       });
       return;
     }
@@ -465,10 +465,10 @@ function PostEditor({ theme, toggleTheme }) {
       setFeedback({
         type: 'success',
         message: postData.scheduledPublish
-          ? 'Post agendado com sucesso!'
+          ? t('editor.notifications.scheduled')
           : publish
-            ? 'Post publicado com sucesso!'
-            : 'Rascunho salvo com sucesso!',
+            ? t('editor.notifications.published')
+            : t('editor.notifications.draftSaved'),
         duration: 3000
       });
       
@@ -495,7 +495,7 @@ function PostEditor({ theme, toggleTheme }) {
       
       setFeedback({
         type: 'error',
-        message: `Ocorreu um erro ao salvar o post: ${error.message}`
+        message: t('editor.notifications.error', { message: error.message })
       });
     } finally {
       setSaving(false);
@@ -608,12 +608,12 @@ function PostEditor({ theme, toggleTheme }) {
         <h1>{t('editor.title')}</h1>
         
         <div className="editor-actions">
-          <button 
-            className="save-draft-button" 
+          <button
+            className="save-draft-button"
             onClick={handleSaveAsDraft}
             disabled={saving}
           >
-            {saving ? 'Salvando...' : 'Salvar Rascunho'}
+            {saving ? t('editor.saving.saving') : t('editor.buttons.saveDraft')}
           </button>
           
           <button 
@@ -621,7 +621,7 @@ function PostEditor({ theme, toggleTheme }) {
             onClick={handlePublish}
             disabled={saving}
           >
-            {saving ? 'Processando...' : (postData.scheduledPublish ? 'Agendar' : 'Publicar')}
+            {saving ? t('editor.saving.saving') : (postData.scheduledPublish ? t('editor.buttons.schedule') : t('editor.buttons.publish'))}
           </button>
         </div>
       </div>
@@ -635,18 +635,18 @@ function PostEditor({ theme, toggleTheme }) {
       )}
       
       {loading ? (
-        <div className="loading">Carregando...</div>
+        <div className="loading">{t('common.loading')}</div>
       ) : (
         <>
           <div className="blog-selector">
-            <label>Blog:</label>
-            <select 
-              value={selectedBlog} 
+            <label>{t('editor.labels.blog')}</label>
+            <select
+              value={selectedBlog}
               onChange={(e) => setSelectedBlog(e.target.value)}
               disabled={!!postId} // Não permitir trocar o blog ao editar um post existente
             >
               {blogs.length === 0 ? (
-                <option value="">Carregando blogs...</option>
+                <option value="">{t('dashboard.loadingBlogs')}</option>
               ) : (
                 blogs.map(blog => (
                   <option key={blog.id} value={blog.id}>{blog.name}</option>
@@ -659,7 +659,7 @@ function PostEditor({ theme, toggleTheme }) {
             <div className="title-input">
               <input
                 type="text"
-                placeholder="Título do post"
+                placeholder={t('editor.placeholders.title')}
                 value={postData.title}
                 onChange={handleTitleChange}
               />
@@ -667,26 +667,26 @@ function PostEditor({ theme, toggleTheme }) {
             
             <div className="post-actions">
               <div className="labels-input">
-                <label>Tags (separadas por vírgula):</label>
+                <label>{t('editor.labels.tags')}</label>
                 <input
                   type="text"
                   value={postData.labels.join(', ')}
                   onChange={handleLabelsChange}
-                  placeholder="Exemplo: tecnologia, tutorial, dicas"
+                  placeholder={t('editor.placeholders.tags')}
                 />
               </div>
               
               <div className="template-select">
-                <label>Template:</label>
+                <label>{t('editor.labels.template')}</label>
                 <select onChange={handleTemplateSelect} value={selectedTemplate?.id || 0}>
-                  <option value={0}>Selecionar template...</option>
+                  <option value={0}>{t('editor.templates.select')}</option>
                   {templates.map(template => (
                     <option key={template.id} value={template.id}>
                       {template.name}
                     </option>
                   ))}
                 </select>
-                <button onClick={handleSaveTemplate}>Salvar como Template</button>
+                <button onClick={handleSaveTemplate}>{t('editor.buttons.saveTemplate')}</button>
               </div>
               
               <div className="schedule-input">
@@ -696,7 +696,7 @@ function PostEditor({ theme, toggleTheme }) {
                     checked={!!postData.scheduledPublish}
                     onChange={() => handleScheduleChange(postData.scheduledPublish ? null : new Date())}
                   />
-                  Agendar publicação
+                  {t('editor.labels.schedule')}
                 </label>
                 
                 {postData.scheduledPublish && (
@@ -705,10 +705,7 @@ function PostEditor({ theme, toggleTheme }) {
                     value={postData.scheduledPublish}
                     minDate={new Date()}
                     format="dd/MM/yyyy HH:mm"
-                    locale="pt-BR"
-                    formatShortWeekday={(locale, date) =>
-                      ['DOM', 'SEG', 'TER', 'QUA', 'QUI', 'SEX', 'SAB'][date.getDay()]
-                    }
+                    locale={i18n.getLocale()}
                   />
                 )}
               </div>
@@ -720,64 +717,64 @@ function PostEditor({ theme, toggleTheme }) {
                     checked={postData.isDraft}
                     onChange={handleDraftToggle}
                   />
-                  Salvar como rascunho
+                  {t('editor.labels.draft')}
                 </label>
               </div>
               
               <div className="metadata-toggle">
-                <button onClick={() => setShowMetadataEditor(!showMetadataEditor)}>
-                  {showMetadataEditor ? 'Esconder Metadados' : 'Editar Metadados'}
-                </button>
+                  <button onClick={() => setShowMetadataEditor(!showMetadataEditor)}>
+                    {showMetadataEditor ? t('editor.buttons.hideMetadata') : t('editor.buttons.showMetadata')}
+                  </button>
               </div>
               
               <div className="import-export">
-                <button onClick={handleExportWord}>Exportar como Word</button>
-                <label className="file-input-label">
-                  Importar Arquivo
-                  <input
-                    type="file"
-                    accept=".txt,.doc,.docx,.html"
-                    onChange={handleFileImport}
-                    style={{ display: 'none' }}
-                  />
-                </label>
+                  <button onClick={handleExportWord}>{t('editor.buttons.exportWord')}</button>
+                  <label className="file-input-label">
+                    {t('editor.buttons.importFile')}
+                    <input
+                      type="file"
+                      accept=".txt,.doc,.docx,.html"
+                      onChange={handleFileImport}
+                      style={{ display: 'none' }}
+                    />
+                  </label>
+                </div>
               </div>
-            </div>
             
             {showMetadataEditor && (
-              <div className="metadata-editor">
-                <h3>Metadados</h3>
+                <div className="metadata-editor">
+                  <h3>{t('editor.metadata.title')}</h3>
+
+                  <div className="metadata-field">
+                    <label>{t('editor.metadata.description')}</label>
+                    <input
+                      type="text"
+                      value={metadata.description}
+                      onChange={(e) => handleMetadataChange(e, 'description')}
+                      placeholder={t('editor.metadata.descriptionPlaceholder')}
+                    />
+                  </div>
                 
                 <div className="metadata-field">
-                  <label>Descrição (SEO):</label>
-                  <input
-                    type="text"
-                    value={metadata.description}
-                    onChange={(e) => handleMetadataChange(e, 'description')}
-                    placeholder="Breve descrição do post para motores de busca"
-                  />
-                </div>
+                    <label>{t('editor.metadata.author')}</label>
+                    <input
+                      type="text"
+                      value={metadata.author}
+                      onChange={(e) => handleMetadataChange(e, 'author')}
+                      placeholder={t('editor.metadata.authorPlaceholder')}
+                    />
+                  </div>
                 
                 <div className="metadata-field">
-                  <label>Autor:</label>
-                  <input
-                    type="text"
-                    value={metadata.author}
-                    onChange={(e) => handleMetadataChange(e, 'author')}
-                    placeholder="Nome do autor"
-                  />
+                    <label>{t('editor.metadata.keywords')}</label>
+                    <input
+                      type="text"
+                      value={metadata.keywords}
+                      onChange={(e) => handleMetadataChange(e, 'keywords')}
+                      placeholder={t('editor.metadata.keywordsPlaceholder')}
+                    />
+                  </div>
                 </div>
-                
-                <div className="metadata-field">
-                  <label>Palavras-chave (SEO):</label>
-                  <input
-                    type="text"
-                    value={metadata.keywords}
-                    onChange={(e) => handleMetadataChange(e, 'keywords')}
-                    placeholder="Palavras-chave separadas por vírgula"
-                  />
-                </div>
-              </div>
             )}
           </div>
           
@@ -829,9 +826,9 @@ function PostEditor({ theme, toggleTheme }) {
                     'tableCellProperties', 'tableProperties'
                   ]
                 },
-                language: 'pt-br'
-              }}
-            />
+                  language: i18n.getLocale().split('-')[0]
+                }}
+              />
           </div>
         </>
       )}
@@ -839,10 +836,10 @@ function PostEditor({ theme, toggleTheme }) {
       {/* Indicador de salvamento */}
       {saving && (
         <div className="save-indicator show saving">
-          Salvando...
-        </div>
-      )}
-    </div>
+            {t('editor.saving.saving')}
+          </div>
+        )}
+      </div>
   );
 }
 

--- a/src/components/TemplatesManager.js
+++ b/src/components/TemplatesManager.js
@@ -46,10 +46,10 @@ function TemplatesManager({ theme }) {
     } catch (error) {
       console.error('Erro ao carregar templates:', error);
       setTemplates([]);
-      setFeedback({
-        type: 'error',
-        message: 'Erro ao carregar templates. Os dados podem estar corrompidos.'
-      });
+        setFeedback({
+          type: 'error',
+          message: t('templates.notifications.loadError')
+        });
     }
   };
   
@@ -67,18 +67,18 @@ function TemplatesManager({ theme }) {
    * Inicia a criação de um novo template
    */
   const handleCreateTemplate = () => {
-    const newTemplate = {
-      id: Date.now(),
-      name: 'Novo Template',
-      description: '',
-      content: '',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
-    
-    setSelectedTemplate(newTemplate);
-    setTemplateName('Novo Template');
-    setTemplateDescription('');
+      const newTemplate = {
+        id: Date.now(),
+        name: t('templates.newTemplate'),
+        description: '',
+        content: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      setSelectedTemplate(newTemplate);
+      setTemplateName(t('templates.newTemplate'));
+      setTemplateDescription('');
     setIsEditing(true);
   };
   
@@ -89,7 +89,7 @@ function TemplatesManager({ theme }) {
     if (!templateName.trim()) {
       setFeedback({
         type: 'error',
-        message: 'Por favor, informe um nome para o template.'
+        message: t('templates.notifications.nameRequired')
       });
       return;
     }
@@ -97,7 +97,7 @@ function TemplatesManager({ theme }) {
     if (!editorRef.current || !editorRef.current.getData) {
       setFeedback({
         type: 'error',
-        message: 'Editor não inicializado. Por favor, tente novamente.'
+        message: t('templates.notifications.editorNotReady')
       });
       return;
     }
@@ -107,7 +107,7 @@ function TemplatesManager({ theme }) {
     if (!content.trim()) {
       setFeedback({
         type: 'error',
-        message: 'O conteúdo do template não pode estar vazio.'
+        message: t('templates.notifications.contentRequired')
       });
       return;
     }
@@ -141,7 +141,7 @@ function TemplatesManager({ theme }) {
     
     setFeedback({
       type: 'success',
-      message: 'Template salvo com sucesso!',
+      message: t('templates.notifications.saved'),
       duration: 3000
     });
   };
@@ -150,7 +150,7 @@ function TemplatesManager({ theme }) {
    * Exclui um template
    */
   const handleDeleteTemplate = (templateId) => {
-    if (!window.confirm('Tem certeza que deseja excluir este template? Esta ação não pode ser desfeita.')) {
+    if (!window.confirm(t('templates.actions.confirmDelete'))) {
       return;
     }
     
@@ -171,7 +171,7 @@ function TemplatesManager({ theme }) {
     
     setFeedback({
       type: 'success',
-      message: 'Template excluído com sucesso!',
+      message: t('templates.notifications.deleted'),
       duration: 3000
     });
   };
@@ -192,7 +192,7 @@ function TemplatesManager({ theme }) {
     if (templates.length === 0) {
       setFeedback({
         type: 'error',
-        message: 'Não há templates para exportar.'
+        message: t('templates.notifications.noTemplatesExport')
       });
       return;
     }
@@ -226,15 +226,15 @@ function TemplatesManager({ theme }) {
           if (validTemplates.length === 0) {
             setFeedback({
               type: 'error',
-              message: 'Nenhum template válido encontrado no arquivo.'
+              message: t('templates.importDialog.noValidTemplates')
             });
             return;
           }
           
           // Perguntar se deseja substituir ou mesclar
           const shouldReplace = window.confirm(
-            `Importar ${validTemplates.length} templates. Deseja substituir todos os templates existentes? ` +
-            `Escolha "OK" para substituir ou "Cancelar" para mesclar com os templates existentes.`
+            t('templates.importDialog.replaceOrMerge', { count: validTemplates.length }) + ' ' +
+            t('templates.importDialog.replaceConfirm')
           );
           
           let updatedTemplates;
@@ -258,9 +258,9 @@ function TemplatesManager({ theme }) {
             
             if (conflictingTemplates.length > 0) {
               const shouldOverwrite = window.confirm(
-                `${conflictingTemplates.length} templates têm IDs conflitantes. ` +
-                `Deseja sobrescrever os templates existentes com o mesmo ID? ` +
-                `Escolha "OK" para sobrescrever ou "Cancelar" para manter os templates existentes.`
+                t('templates.importDialog.conflictDetected', { count: conflictingTemplates.length }) + ' ' +
+                t('templates.importDialog.conflictAction') + ' ' +
+                t('templates.importDialog.conflictConfirm')
               );
               
               if (shouldOverwrite) {
@@ -292,7 +292,7 @@ function TemplatesManager({ theme }) {
           
           setFeedback({
             type: 'success',
-            message: `Importação concluída! ${validTemplates.length} templates importados.`,
+        message: t('templates.importDialog.importSuccess', { count: validTemplates.length }),
             duration: 3000
           });
         } else if (importedData.id && importedData.name && importedData.content) {
@@ -314,20 +314,20 @@ function TemplatesManager({ theme }) {
           
           setFeedback({
             type: 'success',
-            message: `Template "${newTemplate.name}" importado com sucesso!`,
+          message: t('templates.notifications.saved'),
             duration: 3000
           });
         } else {
-          setFeedback({
-            type: 'error',
-            message: 'O arquivo não contém templates válidos.'
-          });
+        setFeedback({
+          type: 'error',
+          message: t('templates.importDialog.noValidTemplates')
+        });
         }
       } catch (error) {
         console.error('Erro ao importar templates:', error);
         setFeedback({
           type: 'error',
-          message: 'Erro ao processar o arquivo. Verifique se é um arquivo JSON válido.'
+          message: t('templates.importDialog.importError', { message: t('templates.importDialog.invalidJson') })
         });
       }
     };
@@ -339,7 +339,7 @@ function TemplatesManager({ theme }) {
    * Cancela a edição do template atual
    */
   const handleCancelEdit = () => {
-    if (window.confirm('Há alterações não salvas. Deseja realmente cancelar?')) {
+    if (window.confirm(t('templates.actions.cancelConfirm'))) {
       setSelectedTemplate(null);
       setTemplateName('');
       setTemplateDescription('');
@@ -361,7 +361,7 @@ function TemplatesManager({ theme }) {
    * Formata a data para exibição
    */
   const formatDate = (dateString) => {
-    return new Date(dateString).toLocaleDateString('pt-BR', {
+    return new Date(dateString).toLocaleDateString(i18n.getLocale(), {
       day: '2-digit',
       month: '2-digit',
       year: 'numeric',
@@ -376,24 +376,24 @@ function TemplatesManager({ theme }) {
         <h1>{t('templates.title')}</h1>
         
         <div className="templates-actions">
-          <button 
-            className="create-template-button" 
+          <button
+            className="create-template-button"
             onClick={handleCreateTemplate}
             disabled={isEditing}
           >
-            Criar Novo Template
+            {t('templates.createNew')}
           </button>
           
-          <button 
-            className="export-all-button" 
+          <button
+            className="export-all-button"
             onClick={handleExportAllTemplates}
             disabled={templates.length === 0}
           >
-            Exportar Todos
+            {t('templates.exportAll')}
           </button>
           
           <label className="import-button">
-            Importar Templates
+            {t('templates.importTemplates')}
             <input
               type="file"
               accept=".json"
@@ -414,12 +414,12 @@ function TemplatesManager({ theme }) {
       
       <div className="templates-layout">
         <div className="templates-list">
-          <h2>Templates Disponíveis ({templates.length})</h2>
+          <h2>{t('templates.availableTemplates', { count: templates.length })}</h2>
           
           {templates.length === 0 ? (
             <div className="templates-empty">
-              <p>Nenhum template disponível.</p>
-              <p>Crie um novo template ou importe templates existentes.</p>
+              <p>{t('templates.noTemplates')}</p>
+              <p>{t('templates.createOrImport')}</p>
             </div>
           ) : (
             templates.map(template => (
@@ -441,25 +441,25 @@ function TemplatesManager({ theme }) {
                   <button
                     className="use-template-button"
                     onClick={() => handleUseTemplate(template)}
-                    title="Usar este template para criar um novo post"
+                    title={t('templates.actions.use')}
                   >
-                    Usar
+                    {t('templates.actions.use')}
                   </button>
                   
                   <button
                     className="export-template-button"
                     onClick={() => handleExportTemplate(template)}
-                    title="Exportar este template como arquivo JSON"
+                    title={t('templates.actions.export')}
                   >
-                    Exportar
+                    {t('templates.actions.export')}
                   </button>
                   
                   <button 
                     className="delete-template-button"
                     onClick={() => handleDeleteTemplate(template.id)}
-                    title="Excluir este template"
+                    title={t('templates.actions.delete')}
                   >
-                    Excluir
+                    {t('templates.actions.delete')}
                   </button>
                 </div>
               </div>
@@ -470,51 +470,51 @@ function TemplatesManager({ theme }) {
         {isEditing && selectedTemplate && (
           <div className="template-editor">
             <div className="template-editor-header">
-              <h2>{selectedTemplate.id ? 'Editar Template' : 'Novo Template'}</h2>
+              <h2>{selectedTemplate.id ? t('templates.editTemplate') : t('templates.newTemplate')}</h2>
               
               <div className="template-editor-actions">
                 <button 
-                  className="save-template-button" 
+                  className="save-template-button"
                   onClick={handleSaveTemplate}
                 >
-                  Salvar Template
+                  {t('templates.actions.save')}
                 </button>
                 
                 <button
                   className="cancel-edit-button"
                   onClick={handleCancelEdit}
                 >
-                  Cancelar
+                  {t('templates.actions.cancel')}
                 </button>
               </div>
             </div>
             
             <div className="template-form">
               <div className="template-form-field">
-                <label htmlFor="template-name">Nome do Template:</label>
+                <label htmlFor="template-name">{t('templates.templateName')}</label>
                 <input
                   id="template-name"
                   type="text"
                   value={templateName}
                   onChange={(e) => setTemplateName(e.target.value)}
-                  placeholder="Digite um nome para o template"
+                  placeholder={t('templates.placeholders.name')}
                   required
                 />
               </div>
               
               <div className="template-form-field">
-                <label htmlFor="template-description">Descrição (opcional):</label>
+                <label htmlFor="template-description">{t('templates.templateDescription')}</label>
                 <input
                   id="template-description"
                   type="text"
                   value={templateDescription}
                   onChange={(e) => setTemplateDescription(e.target.value)}
-                  placeholder="Uma breve descrição do template"
+                  placeholder={t('templates.placeholders.description')}
                 />
               </div>
               
               <div className="template-editor-content">
-                <label>Conteúdo do Template:</label>
+                <label>{t('templates.templateContent')}</label>
                 <CKEditor
                   editor={ClassicEditor}
                   data={selectedTemplate.content}
@@ -542,7 +542,7 @@ function TemplatesManager({ theme }) {
                       '|',
                       'undo', 'redo'
                     ],
-                    language: 'pt-br'
+                    language: i18n.getLocale().split('-')[0]
                   }}
                 />
               </div>
@@ -552,16 +552,15 @@ function TemplatesManager({ theme }) {
         
         {!isEditing && (
           <div className="template-preview">
-            <h2>Selecione um template para editar</h2>
-            <p>Ou clique em "Criar Novo Template" para começar um novo.</p>
+            <h2>{t('templates.selectToEdit')}</h2>
+            <p>{t('templates.orCreateNew')}</p>
             
             <div className="template-tips">
-              <h3>Dicas para Templates</h3>
+              <h3>{t('templates.tips.title')}</h3>
               <ul>
-                <li>Crie templates para tipos específicos de posts (revisões, tutoriais, notícias, etc.)</li>
-                <li>Inclua espaços reservados para o conteúdo que você normalmente adiciona</li>
-                <li>Use estilos consistentes para manter a identidade visual do seu blog</li>
-                <li>Exporte seus templates favoritos para compartilhar com outros usuários</li>
+                {t('templates.tips.items').map((tip, idx) => (
+                  <li key={idx}>{tip}</li>
+                ))}
               </ul>
             </div>
           </div>

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -131,9 +131,15 @@ const translations = {
         published: 'Post published successfully!',
         scheduled: 'Post scheduled successfully!',
         error: 'An error occurred: {message}'
+      },
+      errors: {
+        selectBlog: 'Please select a blog before saving the post.',
+        enterTitle: 'Please enter a title for the post.',
+        loadBlogs: 'Unable to load your blogs. Please check your connection and try again.',
+        loadPost: 'Unable to load the post. Please check your connection and try again.'
       }
     },
-    
+
     templates: {
       title: 'Template Manager',
       createNew: 'Create New Template',
@@ -144,16 +150,23 @@ const translations = {
       createOrImport: 'Create a new template or import existing templates.',
       selectToEdit: 'Select a template to edit',
       orCreateNew: 'Or click "Create New Template" to start a new one.',
+      newTemplate: 'New Template',
+      editTemplate: 'Edit Template',
       templateName: 'Template Name:',
       templateDescription: 'Description (optional):',
       templateContent: 'Template Content:',
+      placeholders: {
+        name: 'Enter a name for the template',
+        description: 'A brief description of the template'
+      },
       actions: {
         save: 'Save Template',
         cancel: 'Cancel',
         use: 'Use',
         export: 'Export',
         delete: 'Delete',
-        confirmDelete: 'Are you sure you want to delete this template? This action cannot be undone.'
+        confirmDelete: 'Are you sure you want to delete this template? This action cannot be undone.',
+        cancelConfirm: 'There are unsaved changes. Do you really want to cancel?'
       },
       tips: {
         title: 'Template Tips',
@@ -164,6 +177,15 @@ const translations = {
           'Export your favorite templates to share with other users'
         ]
       },
+      notifications: {
+        saved: 'Template saved successfully!',
+        deleted: 'Template deleted successfully!',
+        nameRequired: 'Please enter a name for the template.',
+        contentRequired: 'The template content cannot be empty.',
+        editorNotReady: 'Editor not initialized. Please try again.',
+        noTemplatesExport: 'There are no templates to export.',
+        loadError: 'Error loading templates. Data may be corrupted.'
+      },
       importDialog: {
         importSuccess: 'Import completed! {count} templates imported.',
         importError: 'Error importing templates: {message}',
@@ -171,7 +193,9 @@ const translations = {
         replaceConfirm: 'OK to replace or Cancel to merge with existing templates.',
         conflictDetected: '{count} templates have conflicting IDs.',
         conflictAction: 'Do you want to overwrite existing templates with the same ID?',
-        conflictConfirm: 'OK to overwrite or Cancel to keep existing templates.'
+        conflictConfirm: 'OK to overwrite or Cancel to keep existing templates.',
+        noValidTemplates: 'No valid templates found in the file.',
+        invalidJson: 'Invalid JSON file.'
       }
     },
     

--- a/src/locales/pt-PT.js
+++ b/src/locales/pt-PT.js
@@ -131,9 +131,15 @@ const translations = {
         published: 'Artigo publicado com sucesso!',
         scheduled: 'Artigo agendado com sucesso!',
         error: 'Ocorreu um erro: {message}'
+      },
+      errors: {
+        selectBlog: 'Por favor, selecione um blogue antes de guardar o artigo.',
+        enterTitle: 'Por favor, insira um título para o artigo.',
+        loadBlogs: 'Não foi possível carregar os seus blogues. Por favor, verifique a sua conexão e tente novamente.',
+        loadPost: 'Não foi possível carregar o artigo. Por favor, verifique a sua conexão e tente novamente.'
       }
     },
-    
+
     templates: {
       title: 'Gestor de Modelos',
       createNew: 'Criar Novo Modelo',
@@ -144,16 +150,23 @@ const translations = {
       createOrImport: 'Crie um novo modelo ou importe modelos existentes.',
       selectToEdit: 'Selecione um modelo para editar',
       orCreateNew: 'Ou clique em "Criar Novo Modelo" para começar um novo.',
+      newTemplate: 'Novo Modelo',
+      editTemplate: 'Editar Modelo',
       templateName: 'Nome do Modelo:',
       templateDescription: 'Descrição (opcional):',
       templateContent: 'Conteúdo do Modelo:',
+      placeholders: {
+        name: 'Digite um nome para o modelo',
+        description: 'Uma breve descrição do modelo'
+      },
       actions: {
         save: 'Guardar Modelo',
         cancel: 'Cancelar',
         use: 'Usar',
         export: 'Exportar',
         delete: 'Eliminar',
-        confirmDelete: 'Tem a certeza que deseja eliminar este modelo? Esta ação não pode ser desfeita.'
+        confirmDelete: 'Tem a certeza que deseja eliminar este modelo? Esta ação não pode ser desfeita.',
+        cancelConfirm: 'Há alterações não guardadas. Deseja realmente cancelar?'
       },
       tips: {
         title: 'Dicas para Modelos',
@@ -164,6 +177,15 @@ const translations = {
           'Exporte os seus modelos favoritos para partilhar com outros utilizadores'
         ]
       },
+      notifications: {
+        saved: 'Modelo guardado com sucesso!',
+        deleted: 'Modelo eliminado com sucesso!',
+        nameRequired: 'Por favor, informe um nome para o modelo.',
+        contentRequired: 'O conteúdo do modelo não pode estar vazio.',
+        editorNotReady: 'Editor não inicializado. Por favor, tente novamente.',
+        noTemplatesExport: 'Não há modelos para exportar.',
+        loadError: 'Erro ao carregar modelos. Os dados podem estar corrompidos.'
+      },
       importDialog: {
         importSuccess: 'Importação concluída! {count} modelos importados.',
         importError: 'Erro ao importar modelos: {message}',
@@ -171,7 +193,9 @@ const translations = {
         replaceConfirm: 'OK para substituir ou Cancelar para mesclar com os modelos existentes.',
         conflictDetected: '{count} modelos têm IDs conflitantes.',
         conflictAction: 'Deseja sobrescrever os modelos existentes com o mesmo ID?',
-        conflictConfirm: 'OK para sobrescrever ou Cancelar para manter os modelos existentes.'
+        conflictConfirm: 'OK para sobrescrever ou Cancelar para manter os modelos existentes.',
+        noValidTemplates: 'Nenhum modelo válido encontrado no ficheiro.',
+        invalidJson: 'Ficheiro JSON inválido.'
       }
     },
     

--- a/src/services/I18nService.js
+++ b/src/services/I18nService.js
@@ -116,8 +116,9 @@ class I18nService {
     if (typeof value === 'string') {
       return this._interpolate(value, params);
     }
-    
-    return String(value);
+
+    // Retornar arrays ou objetos como estão
+    return value;
   }
   
   /**


### PR DESCRIPTION
## Summary
- internationalize post editor buttons, labels, and metadata fields
- translate template manager UI and import dialogs
- extend i18n service and locale files with missing keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb2d1f7f88324b6602e052936bf27