### PR TITLE
chore: improve dev server compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ BlogCraft is a modern web application designed to replace discontinued tools lik
 - Ensure browser supports modern OAuth flows
 - If you receive 401/403 errors, remove the local token (`localStorage` key: `blogcraft_token`) and sign in again
 - The project uses `react-scripts` with `--openssl-legacy-provider` set in `npm` scripts for compatibility on Node 18
+- On Windows, if the dev server fails due to a locked `C:\\DumpStack.log.tmp` file or similar watch errors, start it with `CHOKIDAR_USEPOLLING=true npm start` or run the project from a directory outside the root `C:\` drive. For custom watchers, ignore `C:\\DumpStack.log.tmp`.
 
 ## 🧪 Build & Test
 

--- a/run.bat
+++ b/run.bat
@@ -7,4 +7,5 @@ IF NOT EXIST node_modules (
 )
 
 set NODE_OPTIONS=--openssl-legacy-provider
+set CHOKIDAR_USEPOLLING=true
 npx react-scripts start

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,5 @@ if [ ! -d node_modules ]; then
 fi
 
 export NODE_OPTIONS=--openssl-legacy-provider
+export CHOKIDAR_USEPOLLING=true
 npx react-scripts start


### PR DESCRIPTION
## Summary
- export `CHOKIDAR_USEPOLLING=true` in dev run scripts
- document Windows watcher workaround in Troubleshooting section

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689fb816cf708324b4f9f1b56a612ca4