### PR TITLE
Add AI assistant (GPT/Gemini/Claude) and improve editor mechanics

### DIFF
--- a/Project_Structure.md
+++ b/Project_Structure.md
@@ -1,157 +1,129 @@
 # Estrutura do Projeto BlogCraft
 
-Abaixo está a estrutura de arquivos recomendada para o projeto BlogCraft:
+Estrutura atual do repositório (ficheiros relevantes):
 
 ```
 blogcraft/
-├── node_modules/
-├── public/
-│   ├── index.html
-│   ├── logo.svg
-│   ├── logo192.png
-│   ├── logo512.png
-│   ├── manifest.json
-│   └── robots.txt
+├── .github/workflows/        # Workflow de release (binários portáveis)
+├── docs/screenshots/         # Capturas de ecrã usadas no README
+├── public/                   # Ficheiros estáticos (index.html, logos, manifest)
 ├── src/
 │   ├── components/
-│   │   ├── Dashboard.js
-│   │   ├── PostEditor.js
-│   │   ├── Settings.js
-│   │   ├── Sidebar.js
-│   │   └── TemplatesManager.js
+│   │   ├── AIAssistant.js       # Painel de chat com IA no editor
+│   │   ├── AISelectionMenu.js   # Menu flutuante de IA sobre texto selecionado
+│   │   ├── AuthDebugger.js      # Ferramenta de depuração de autenticação
+│   │   ├── Dashboard.js         # Painel com blogues, posts recentes e estatísticas
+│   │   ├── Feedback.js          # Mensagens de feedback (sucesso/erro/info)
+│   │   ├── LanguageSelector.js  # Seletor de idioma no login
+│   │   ├── Login.js             # Autenticação Google OAuth
+│   │   ├── LoginDebugger.js     # Overlay de depuração do login
+│   │   ├── PostEditor.js        # Editor de artigos (CKEditor 5 + IA)
+│   │   ├── Settings.js          # Definições (incl. fornecedor de IA)
+│   │   ├── Sidebar.js           # Navegação lateral
+│   │   └── TemplatesManager.js  # Gestor de modelos de conteúdo
+│   ├── locales/
+│   │   ├── en-US.js             # Traduções em inglês
+│   │   └── pt-PT.js             # Traduções em português
 │   ├── services/
-│   │   └── BloggerService.js
+│   │   ├── AIService.js         # Integração multi-fornecedor de IA (GPT/Gemini/Claude)
+│   │   ├── AIService.test.js    # Testes do serviço de IA
+│   │   ├── AuthService.js       # Gestão de tokens e sessão Google
+│   │   ├── BloggerService.js    # Cliente da API do Blogger (cache, timeouts)
+│   │   ├── BloggerService.test.js
+│   │   ├── I18nService.js       # Serviço de internacionalização
+│   │   └── TokenManager.js      # Utilitários de token
 │   ├── styles/
+│   │   ├── ai.css               # Estilos do assistente de IA
+│   │   ├── app.css              # Estilos globais e layout
 │   │   ├── dashboard.css
+│   │   ├── debug.css
 │   │   ├── editor.css
+│   │   ├── feedback.css
+│   │   ├── index.css
 │   │   ├── settings.css
 │   │   └── templates.css
 │   ├── utils/
+│   │   ├── ckeditorExtensions.js # Plugins runtime do CKEditor (upload base64,
+│   │   │                         # preservação de largura/altura de imagens,
+│   │   │                         # configuração de toolbar)
 │   │   ├── dateUtils.js
-│   │   └── fileUtils.js
-│   ├── App.css
-│   ├── App.js
-│   ├── App.test.js
-│   ├── index.css
-│   ├── index.js
-│   ├── logo.svg
+│   │   ├── fileUtils.js
+│   │   ├── logger.js
+│   │   └── storage.js            # Acesso seguro ao localStorage
+│   ├── App.js                    # Rotas e layout autenticado
+│   ├── BlogCraft.js
+│   ├── index.js                  # Entrada da aplicação (GoogleOAuthProvider)
 │   ├── reportWebVitals.js
 │   └── setupTests.js
-├── .gitignore
-├── package-lock.json
+├── build-release.js / .sh / .bat # Empacotamento portátil (pkg)
+├── config-overrides.js           # Overrides do webpack (CSS do CKEditor)
+├── scheduler.js                  # Serviço opcional de publicação agendada
+├── server.js                     # Servidor estático de produção
 ├── package.json
-└── README.md
+├── README.md / README_PT.md
+└── Project_Structure.md
 ```
 
-## Passos para Implementação
+## Arquitetura
 
-1. **Configuração da Estrutura de Pastas**:
-   - Criar as pastas `components`, `services`, `styles` e `utils` dentro de `src`
-   - Mover os arquivos desenvolvidos para as pastas apropriadas
+- **UI**: React 18 com `react-router-dom` (HashRouter). Tema claro/escuro
+  aplicado via classe no `body`.
+- **Editor**: CKEditor 5 (build clássico) com plugins runtime adicionais em
+  `src/utils/ckeditorExtensions.js`:
+  - upload de imagens do disco como data URLs base64;
+  - preservação dos atributos `width`/`height` das imagens (necessário para o
+    redimensionamento feito pela IA e por conteúdo importado);
+  - toolbar limitada às funcionalidades realmente existentes no build.
+- **Assistente de IA** (`src/services/AIService.js`):
+  - Fornecedores suportados: OpenAI (GPT), Google (Gemini), Anthropic (Claude).
+  - A chave de API é fornecida pelo utilizador e guardada apenas no
+    `localStorage` (`blogcraft_ai_settings`); os pedidos vão diretamente do
+    navegador para o fornecedor.
+  - Protocolo de ações em JSON: o modelo devolve `{"reply", "actions"}` e o
+    editor aplica `replace_document`, `insert_html`, `replace_selection` e
+    `set_title` através do modelo do CKEditor (compatível com undo).
+  - `transformSelection()` reescreve fragmentos HTML selecionados (menu
+    flutuante de seleção).
+- **Blogger**: `BloggerService.js` encapsula a API v3 com cache de 5 minutos,
+  timeouts e mensagens de erro tratadas.
+- **i18n**: `I18nService.js` + `src/locales/*.js` (en-US, pt-PT).
 
-2. **Instalar Dependências**:
-   ```bash
-   npm install @tinymce/tinymce-react react-datetime-picker file-saver @react-oauth/google react-router-dom
-   ```
+## Dados no localStorage
 
-3. **Configuração do OAuth**:
-   - Confirmar que o Client ID do OAuth está correto em `index.js`:
-   ```javascript
-   const CLIENT_ID = "404858006833-cs2qa9oank867t1jkpttus0uq1m7nnfm.apps.googleusercontent.com";
-   ```
+| Chave                     | Conteúdo                                    |
+| ------------------------- | ------------------------------------------- |
+| `blogcraft_token`         | Access token Google/Blogger                 |
+| `blogcraft_settings`      | Preferências gerais                         |
+| `blogcraft_ai_settings`   | Fornecedor de IA, chaves e modelos          |
+| `blogcraft_templates`     | Modelos de conteúdo                         |
+| `blogcraft_draft_*`       | Rascunhos locais auto-guardados             |
+| `blogcraft_locale`        | Idioma da interface                         |
+| `theme`                   | Tema claro/escuro                           |
 
-4. **Implementação dos Componentes**:
-   - Copiar os componentes desenvolvidos para suas respectivas pastas
-   - Atualizar as importações em cada arquivo para refletir a nova estrutura
+## Planeamento (roadmap)
 
-5. **Implementação dos Estilos**:
-   - Copiar os estilos CSS para seus respectivos arquivos
-   - Importar os estilos em `App.css` ou nos componentes apropriados
+Curto prazo:
+- [x] Assistente de IA integrado no editor (chat + ações no documento)
+- [x] Menu de IA sobre seleção de texto (melhorar/corrigir/encurtar/expandir/pedido livre)
+- [x] Inserção de imagens do disco (base64) e redimensionamento/posicionamento
+- [x] Restauro de rascunhos locais auto-guardados
+- [x] Aplicação do blogue e modelo padrão definidos nas Definições
+- [ ] Streaming das respostas de IA no painel de chat
+- [ ] Upload de imagens para um serviço de alojamento (em vez de base64)
+- [ ] Variáveis de modelo mais poderosas (placeholders dinâmicos)
 
-6. **Configuração dos Arquivos Principais**:
-   - Atualizar `App.js` e `index.js` com o código desenvolvido
+Médio prazo:
+- [ ] Sugestões de SEO geradas por IA a partir do conteúdo
+- [ ] Histórico de conversas de IA por artigo
+- [ ] Suporte offline melhorado
 
-## Utilitários Adicionais
+## Testes
 
-### dateUtils.js
-
-```javascript
-/**
- * Formata uma data para exibição
- * @param {string|Date} date - Data para formatar
- * @returns {string} Data formatada
- */
-export const formatDate = (date) => {
-  if (!date) return '';
-  
-  const dateObj = typeof date === 'string' ? new Date(date) : date;
-  
-  return dateObj.toLocaleDateString('pt-BR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  });
-};
-
-/**
- * Verifica se uma data está no futuro
- * @param {string|Date} date - Data para verificar
- * @returns {boolean} True se a data estiver no futuro
- */
-export const isFutureDate = (date) => {
-  if (!date) return false;
-  
-  const dateObj = typeof date === 'string' ? new Date(date) : date;
-  const now = new Date();
-  
-  return dateObj > now;
-};
+```bash
+npm test -- --watchAll=false   # Jest (serviços)
+npm run build                  # Build de produção
 ```
 
-### fileUtils.js
-
-```javascript
-/**
- * Extrai nome e extensão de um arquivo
- * @param {string} filename - Nome do arquivo
- * @returns {Object} Objeto contendo nome e extensão
- */
-export const parseFileName = (filename) => {
-  const lastDot = filename.lastIndexOf('.');
-  
-  if (lastDot === -1) {
-    return { name: filename, extension: '' };
-  }
-  
-  return {
-    name: filename.substring(0, lastDot),
-    extension: filename.substring(lastDot + 1).toLowerCase()
-  };
-};
-
-/**
- * Verifica se a extensão do arquivo é suportada
- * @param {string} filename - Nome do arquivo
- * @param {Array} supportedExtensions - Lista de extensões suportadas
- * @returns {boolean} True se a extensão for suportada
- */
-export const isExtensionSupported = (filename, supportedExtensions) => {
-  const { extension } = parseFileName(filename);
-  
-  return supportedExtensions.includes(extension);
-};
-```
-
-## Considerações Finais
-
-Ao implementar o projeto, certifique-se de:
-
-1. Verificar que todas as importações estão corretas
-2. Testar o fluxo completo de autenticação e integração com o Blogger
-3. Verificar a responsividade em diferentes dispositivos
-4. Testar o tema claro e escuro
-5. Verificar o tratamento de erros em todos os componentes
-
-Para obter uma chave da API do TinyMCE, visite [https://www.tiny.cloud/](https://www.tiny.cloud/) e registre-se para uma conta gratuita. A chave deve ser adicionada nos componentes que utilizam o editor.
+Os testes cobrem o `BloggerService` e o `AIService` (definições, análise do
+protocolo de ações, sanitização de HTML e transportes dos três fornecedores
+com `fetch` simulado).

--- a/README.md
+++ b/README.md
@@ -26,11 +26,55 @@ donation button below.
 
 ## 🆕 What's New
 
+- **AI Assistant**: connect your own OpenAI (GPT), Google (Gemini) or
+  Anthropic (Claude) API key and let the AI write, edit and illustrate posts
+  directly inside the editor — via chat, quick-action buttons, or a floating
+  menu over selected text.
+- Text-editing fixes: working image upload (embedded as base64), image
+  size/position preserved while editing, cleaned-up toolbar, word/character
+  count, auto-saved draft restore, and default blog/template applied from
+  Settings.
 - Portable Windows release opens BlogCraft automatically and falls back to the
   next local port if `3000` is busy.
 - Windows `.exe` builds include the BlogCraft logo/icon.
 - Refreshed dashboard/editor/template styling and README screenshots.
 - Added a PayPal donation button for project support.
+
+## 🤖 AI Assistant (GPT / Gemini / Claude)
+
+BlogCraft can connect to an AI provider of your choice using your own API key
+or subscription. Everything runs in your browser: the key is stored only in
+`localStorage` and requests go directly from your browser to the provider.
+
+### Setup
+
+1. Open **Settings → AI Assistant**.
+2. Enable the assistant and pick a provider:
+   - **OpenAI (GPT)** — key from <https://platform.openai.com/api-keys>
+   - **Google (Gemini)** — key from <https://aistudio.google.com/app/apikey>
+   - **Anthropic (Claude)** — key from <https://console.anthropic.com/settings/keys>
+3. Paste your API key, optionally pick a model, and press **Test Connection**.
+4. Save the settings.
+
+### Using the assistant in the editor
+
+- Click **✨ AI Assistant** in the Post Editor header to open the chat panel.
+  Ask the AI to write a full article, restructure sections, fix the tone,
+  add a summary, suggest a title, or insert images — the changes are applied
+  directly in the text box and can be undone with `Ctrl+Z`.
+- Quick-action buttons (Improve writing, Fix grammar, Continue writing,
+  Add summary, Suggest title, Suggest images) run common requests in one click.
+- **Select any text** in the editor to get a floating AI menu with
+  *Improve*, *Fix grammar*, *Shorten*, *Expand* and *Ask AI* (free-form
+  instruction). The selected fragment is rewritten in place.
+- The AI can insert images, and change their position (left/center/right/side)
+  and size; you can also adjust images manually with the image toolbar.
+
+### Notes on privacy and cost
+
+- Your API key never leaves your machine except to call the provider you chose.
+- AI requests are billed to your provider account according to their pricing.
+- Avoid storing API keys on shared computers.
 
 ## 🚀 Quick Start
 
@@ -91,15 +135,16 @@ the user's normal two-factor authentication if their account has it enabled.
 
 5. Access the application at `http://localhost:3000`
 
-## ✨ What's new
+## ✨ Feature overview
 
 - Robust Google Sign-In via `@react-oauth/google` with Blogger scope
 - Token handling improvements in `AuthService` and `TokenManager` (session checks, safer storage)
 - `BloggerService` with caching, timeouts, and clearer error messages (401/403/429)
 - Dashboard: blog selector, recent posts, and basic monthly stats
-- Post Editor (TinyMCE): draft/publish, scheduling, labels, metadata injection, import (TXT/HTML/Word) and export to Word
+- Post Editor (CKEditor 5): draft/publish, scheduling, labels, metadata injection, image upload with resize/position, word count, import (TXT/HTML) and export to Word
+- AI Assistant: chat panel, quick actions and selection menu backed by GPT, Gemini or Claude with your own API key
 - Templates Manager: create, edit, delete, and reuse content templates
-- Settings: theme (dark/light), defaults, autosave/backup options
+- Settings: theme (dark/light), defaults, autosave/backup options, AI provider configuration
 - i18n foundations (`en-US`, `pt-PT`) and improved styling
 
 ## 🔑 Authentication Guide
@@ -246,8 +291,10 @@ BlogCraft requires minimal permissions to:
 - Access basic profile information
 
 ## 🗺️ Roadmap (short-term)
-- Image upload conveniences and media management
+- Streaming AI responses in the chat panel
+- Image upload to a hosting service (instead of base64 embedding)
 - More powerful template variables and snippets
+- AI-generated SEO suggestions
 - Improved offline/auto-save experience
 
 ---

--- a/README_PT.md
+++ b/README_PT.md
@@ -89,14 +89,65 @@ ativa.
 
 ## ✨ Novidades
 
+- **Assistente de IA**: ligue a sua própria chave de API da OpenAI (GPT),
+  Google (Gemini) ou Anthropic (Claude) e deixe a IA escrever, editar e
+  ilustrar artigos diretamente no editor — via chat, botões de ações rápidas
+  ou um menu flutuante sobre o texto selecionado.
+- Correções na edição de texto: upload de imagens funcional (incorporadas em
+  base64), tamanho/posição das imagens preservados durante a edição, toolbar
+  limpa, contagem de palavras/caracteres, restauro de rascunhos auto-guardados
+  e aplicação do blogue/modelo padrão das Definições.
 - Login Google via `@react-oauth/google` com escopo do Blogger
 - Melhorias no manuseio de token em `AuthService` e `TokenManager` (verificações de sessão, armazenamento mais seguro)
 - `BloggerService` com cache, timeouts e mensagens de erro mais claras (401/403/429)
 - Dashboard: seleção de blog, posts recentes e estatísticas mensais básicas
-- Editor (TinyMCE): rascunho/publicar, agendamento, etiquetas, injeção de metadados, importação (TXT/HTML/Word) e exportação para Word
+- Editor (CKEditor 5): rascunho/publicar, agendamento, etiquetas, injeção de metadados, importação (TXT/HTML) e exportação para Word
 - Gestor de Templates: criar, editar, apagar e reutilizar templates de conteúdo
-- Definições: tema (escuro/claro), predefinições, opções de autosave/backup
+- Definições: tema (escuro/claro), predefinições, opções de autosave/backup, configuração do fornecedor de IA
 - Fundações de i18n (`en-US`, `pt-PT`) e melhorias de estilo
+
+## 🤖 Assistente de IA (GPT / Gemini / Claude)
+
+O BlogCraft pode ligar-se a um fornecedor de IA à sua escolha usando a sua
+própria chave de API ou subscrição. Tudo corre no seu navegador: a chave é
+guardada apenas no `localStorage` e os pedidos vão diretamente do navegador
+para o fornecedor.
+
+### Configuração
+
+1. Abra **Definições → Assistente de IA**.
+2. Ative o assistente e escolha um fornecedor:
+   - **OpenAI (GPT)** — chave em <https://platform.openai.com/api-keys>
+   - **Google (Gemini)** — chave em <https://aistudio.google.com/app/apikey>
+   - **Anthropic (Claude)** — chave em <https://console.anthropic.com/settings/keys>
+3. Cole a sua chave de API, escolha opcionalmente um modelo e prima
+   **Testar Ligação**.
+4. Guarde as definições.
+
+### Utilização no editor
+
+- Clique em **✨ Assistente IA** no cabeçalho do Editor de Artigos para abrir
+  o painel de chat. Peça à IA para escrever um artigo completo, reestruturar
+  secções, corrigir o tom, adicionar um resumo, sugerir um título ou inserir
+  imagens — as alterações são aplicadas diretamente na caixa de texto e podem
+  ser desfeitas com `Ctrl+Z`.
+- Os botões de ações rápidas (Melhorar escrita, Corrigir gramática, Continuar
+  a escrever, Adicionar resumo, Sugerir título, Sugerir imagens) executam
+  pedidos comuns com um clique.
+- **Selecione qualquer texto** no editor para obter um menu flutuante de IA
+  com *Melhorar*, *Corrigir*, *Encurtar*, *Expandir* e *Pedir à IA* (instrução
+  livre). O fragmento selecionado é reescrito no próprio local.
+- A IA pode inserir imagens e alterar a sua posição (esquerda/centro/direita/
+  lateral) e tamanho; também pode ajustar imagens manualmente com a toolbar
+  de imagem.
+
+### Notas sobre privacidade e custos
+
+- A sua chave de API nunca sai da sua máquina exceto para chamar o fornecedor
+  que escolheu.
+- Os pedidos de IA são faturados na sua conta do fornecedor segundo os preços
+  deste.
+- Evite guardar chaves de API em computadores partilhados.
 
 ## 🔑 Guia de Autenticação
 
@@ -234,8 +285,10 @@ O BlogCraft requer permissões mínimas para:
 - Aceder a informações básicas de perfil
 
 ## 🗺️ Roadmap (curto prazo)
-- Upload de imagens e gestão de media aprimorados
+- Streaming das respostas de IA no painel de chat
+- Upload de imagens para um serviço de alojamento (em vez de base64)
 - Variáveis/snippets de template mais poderosos
+- Sugestões de SEO geradas por IA
 - Experiência offline/autosalvamento melhorada
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blogcraft",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blogcraft",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^35.4.0",
         "@ckeditor/ckeditor5-react": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blogcraft",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Um editor avançado para o Blogger com recursos modernos e integração completa",
   "private": true,
   "homepage": ".",

--- a/server.js
+++ b/server.js
@@ -99,6 +99,12 @@ const openBrowser = (url) => {
       stdio: 'ignore',
       windowsHide: true
     });
+    // spawn() reports a missing opener (e.g. headless Linux without
+    // xdg-open) asynchronously; without this handler the whole server
+    // crashes with an unhandled 'error' event.
+    child.on('error', (error) => {
+      console.warn(`Unable to open the browser automatically: ${error.message}`);
+    });
     child.unref();
   } catch (error) {
     console.warn(`Unable to open the browser automatically: ${error.message}`);

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import './styles/editor.css';
 import './styles/templates.css';
 import './styles/settings.css';
 import './styles/feedback.css';
+import './styles/ai.css';
 
 // Protected route component to handle authentication
 const ProtectedRoute = ({ children }) => {

--- a/src/components/AIAssistant.js
+++ b/src/components/AIAssistant.js
@@ -1,0 +1,197 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import AIService, { getAISettings, getActiveModel, getActiveProvider, isAIConfigured } from '../services/AIService';
+import i18n, { t } from '../services/I18nService';
+
+/**
+ * AIAssistant - Chat panel docked next to the post editor.
+ *
+ * The user talks to the configured AI provider (GPT / Gemini / Claude).
+ * The model can answer in chat and/or return actions that BlogCraft
+ * applies directly to the article: rewrite the document, insert HTML,
+ * replace the current selection, change the title, insert/resize images.
+ */
+function AIAssistant({ getTitle, getContent, getSelectionHtml, applyAction, onClose }) {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [configured, setConfigured] = useState(isAIConfigured());
+  const [settings, setSettings] = useState(getAISettings());
+  const listRef = useRef(null);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    const refresh = () => {
+      setSettings(getAISettings());
+      setConfigured(isAIConfigured());
+    };
+    window.addEventListener('blogcraft_ai_settings_updated', refresh);
+    return () => window.removeEventListener('blogcraft_ai_settings_updated', refresh);
+  }, []);
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [messages, busy]);
+
+  const quickActions = [
+    { id: 'improve', prompt: t('ai.quickPrompts.improve') },
+    { id: 'grammar', prompt: t('ai.quickPrompts.grammar') },
+    { id: 'continue', prompt: t('ai.quickPrompts.continue') },
+    { id: 'summarize', prompt: t('ai.quickPrompts.summarize') },
+    { id: 'titles', prompt: t('ai.quickPrompts.titles') },
+    { id: 'images', prompt: t('ai.quickPrompts.images') }
+  ];
+
+  const send = async (userMessage) => {
+    const text = (userMessage || '').trim();
+    if (!text || busy) return;
+
+    const nextMessages = [...messages, { role: 'user', content: text }];
+    setMessages(nextMessages);
+    setInput('');
+    setBusy(true);
+
+    try {
+      const selectionHtml = getSelectionHtml ? getSelectionHtml() : '';
+      const { reply, actions } = await AIService.chat({
+        history: messages.map(m => ({ role: m.role, content: m.content })),
+        userMessage: text,
+        title: getTitle(),
+        html: getContent(),
+        selectionHtml,
+        locale: i18n.getLocale()
+      });
+
+      let appliedCount = 0;
+      for (const action of actions) {
+        if (applyAction(action)) {
+          appliedCount += 1;
+        }
+      }
+
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: reply || (appliedCount > 0 ? t('ai.chat.changesApplied') : ''),
+        applied: appliedCount
+      }]);
+    } catch (error) {
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: '',
+        error: error.message
+      }]);
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.focus();
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    send(input);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send(input);
+    }
+  };
+
+  const provider = getActiveProvider(settings);
+
+  return (
+    <aside className="ai-panel" aria-label={t('ai.chat.title')}>
+      <div className="ai-panel-header">
+        <div className="ai-panel-title">
+          <span className="ai-spark" aria-hidden="true">✨</span>
+          <div>
+            <strong>{t('ai.chat.title')}</strong>
+            {configured && (
+              <span className="ai-model-badge">{provider.label} · {getActiveModel(settings)}</span>
+            )}
+          </div>
+        </div>
+        <button type="button" className="ai-close-button" onClick={onClose} aria-label={t('common.cancel')}>
+          ×
+        </button>
+      </div>
+
+      {!configured ? (
+        <div className="ai-not-configured">
+          <p>{t('ai.chat.notConfigured')}</p>
+          <Link to="/settings" className="ai-settings-link">
+            {t('ai.chat.openSettings')}
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div className="ai-messages" ref={listRef}>
+            {messages.length === 0 && (
+              <div className="ai-empty-state">
+                <p>{t('ai.chat.emptyState')}</p>
+              </div>
+            )}
+            {messages.map((message, index) => (
+              <div
+                key={index}
+                className={`ai-message ${message.role} ${message.error ? 'error' : ''}`}
+              >
+                {message.error ? (
+                  <span>{t('ai.chat.error', { message: message.error })}</span>
+                ) : (
+                  <span>{message.content}</span>
+                )}
+                {message.applied > 0 && (
+                  <span className="ai-applied-badge">
+                    ✓ {t('ai.chat.changesApplied')}
+                  </span>
+                )}
+              </div>
+            ))}
+            {busy && (
+              <div className="ai-message assistant thinking">
+                <span className="ai-typing">
+                  <i /><i /><i />
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div className="ai-quick-actions">
+            {quickActions.map(action => (
+              <button
+                key={action.id}
+                type="button"
+                className="ai-quick-button"
+                disabled={busy}
+                onClick={() => send(action.prompt)}
+              >
+                {t(`ai.quickActions.${action.id}`)}
+              </button>
+            ))}
+          </div>
+
+          <form className="ai-input-row" onSubmit={handleSubmit}>
+            <textarea
+              ref={inputRef}
+              value={input}
+              rows={2}
+              placeholder={t('ai.chat.placeholder')}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={busy}
+            />
+            <button type="submit" className="ai-send-button" disabled={busy || !input.trim()}>
+              {busy ? '…' : t('ai.chat.send')}
+            </button>
+          </form>
+        </>
+      )}
+    </aside>
+  );
+}
+
+export default AIAssistant;

--- a/src/components/AISelectionMenu.js
+++ b/src/components/AISelectionMenu.js
@@ -1,0 +1,206 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import AIService, { isAIConfigured } from '../services/AIService';
+import i18n, { t } from '../services/I18nService';
+
+/**
+ * AISelectionMenu - Floating tooltip shown when the user selects text
+ * inside the editor. Offers one-click AI corrections (improve, fix
+ * grammar, shorten, expand) plus a free-form "ask AI" instruction that
+ * rewrites the selected fragment in place.
+ */
+function AISelectionMenu({ editor, getTitle, onFeedback }) {
+  const [position, setPosition] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [askMode, setAskMode] = useState(false);
+  const [instruction, setInstruction] = useState('');
+  const menuRef = useRef(null);
+  const busyRef = useRef(false);
+
+  const hide = useCallback(() => {
+    setPosition(null);
+    setAskMode(false);
+    setInstruction('');
+  }, []);
+
+  // Track the selection inside the CKEditor editable and position the
+  // tooltip above it.
+  useEffect(() => {
+    const updateFromSelection = () => {
+      if (busyRef.current) return;
+
+      if (!editor || editor.state === 'destroyed' || !isAIConfigured()) {
+        hide();
+        return;
+      }
+
+      const modelSelection = editor.model.document.selection;
+      if (modelSelection.isCollapsed) {
+        // Keep the menu open while the user types into the ask box.
+        if (!menuRef.current || !menuRef.current.contains(document.activeElement)) {
+          hide();
+        }
+        return;
+      }
+
+      const domSelection = window.getSelection();
+      if (!domSelection || domSelection.rangeCount === 0) return;
+
+      const editableElement = editor.ui.view.editable.element;
+      if (!editableElement || !editableElement.contains(domSelection.anchorNode)) return;
+
+      const rect = domSelection.getRangeAt(0).getBoundingClientRect();
+      if (!rect || (rect.width === 0 && rect.height === 0)) return;
+
+      setPosition({
+        top: rect.top + window.scrollY - 8,
+        left: rect.left + window.scrollX + rect.width / 2
+      });
+    };
+
+    let removeCKListener = null;
+
+    if (editor && editor.model) {
+      const selection = editor.model.document.selection;
+      const handler = () => setTimeout(updateFromSelection, 0);
+      selection.on('change:range', handler);
+      removeCKListener = () => selection.off('change:range', handler);
+    }
+
+    document.addEventListener('selectionchange', updateFromSelection);
+    window.addEventListener('scroll', hide, true);
+
+    return () => {
+      document.removeEventListener('selectionchange', updateFromSelection);
+      window.removeEventListener('scroll', hide, true);
+      if (removeCKListener) removeCKListener();
+    };
+  }, [editor, hide]);
+
+  const getSelectionHtml = () => {
+    if (!editor) return '';
+    try {
+      const fragment = editor.model.getSelectedContent(editor.model.document.selection);
+      return editor.data.stringify(fragment);
+    } catch {
+      return '';
+    }
+  };
+
+  const replaceSelection = (html) => {
+    if (!editor) return false;
+    const viewFragment = editor.data.processor.toView(html);
+    const modelFragment = editor.data.toModel(viewFragment);
+    editor.model.insertContent(modelFragment);
+    return true;
+  };
+
+  const runInstruction = async (instructionText) => {
+    if (!editor || editor.state === 'destroyed' || busy) return;
+
+    const selectionHtml = getSelectionHtml();
+    if (!selectionHtml.trim()) {
+      hide();
+      return;
+    }
+
+    setBusy(true);
+    busyRef.current = true;
+
+    try {
+      const replacement = await AIService.transformSelection({
+        selectionHtml,
+        instruction: instructionText,
+        title: getTitle ? getTitle() : '',
+        locale: i18n.getLocale()
+      });
+
+      replaceSelection(replacement);
+      if (onFeedback) {
+        onFeedback({ type: 'success', message: t('ai.selection.applied'), duration: 3000 });
+      }
+    } catch (error) {
+      if (onFeedback) {
+        onFeedback({ type: 'error', message: t('ai.chat.error', { message: error.message }) });
+      }
+    } finally {
+      setBusy(false);
+      busyRef.current = false;
+      hide();
+    }
+  };
+
+  const handleAskSubmit = (e) => {
+    e.preventDefault();
+    if (instruction.trim()) {
+      runInstruction(instruction.trim());
+    }
+  };
+
+  if (!position) return null;
+
+  const actions = [
+    { id: 'improve', prompt: t('ai.selectionPrompts.improve') },
+    { id: 'grammar', prompt: t('ai.selectionPrompts.grammar') },
+    { id: 'shorten', prompt: t('ai.selectionPrompts.shorten') },
+    { id: 'expand', prompt: t('ai.selectionPrompts.expand') }
+  ];
+
+  return (
+    <div
+      ref={menuRef}
+      className="ai-selection-menu"
+      style={{ top: position.top, left: position.left }}
+      // Prevent the editor from losing its selection when clicking here.
+      onMouseDown={(e) => e.preventDefault()}
+      role="toolbar"
+      aria-label={t('ai.selection.label')}
+    >
+      {busy ? (
+        <div className="ai-selection-busy">
+          <span className="ai-typing"><i /><i /><i /></span>
+          <span>{t('ai.selection.working')}</span>
+        </div>
+      ) : askMode ? (
+        <form className="ai-selection-ask" onSubmit={handleAskSubmit}>
+          <input
+            autoFocus
+            type="text"
+            value={instruction}
+            placeholder={t('ai.selection.askPlaceholder')}
+            onChange={(e) => setInstruction(e.target.value)}
+            // Allow typing: the input receives focus, so re-enable mousedown.
+            onMouseDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') hide();
+            }}
+          />
+          <button type="submit" disabled={!instruction.trim()}>
+            {t('ai.chat.send')}
+          </button>
+        </form>
+      ) : (
+        <>
+          {actions.map(action => (
+            <button
+              key={action.id}
+              type="button"
+              className="ai-selection-button"
+              onClick={() => runInstruction(action.prompt)}
+            >
+              {t(`ai.selectionActions.${action.id}`)}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="ai-selection-button ask"
+            onClick={() => setAskMode(true)}
+          >
+            <span role="img" aria-label="AI">✨</span> {t('ai.selectionActions.ask')}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default AISelectionMenu;

--- a/src/components/PostEditor.js
+++ b/src/components/PostEditor.js
@@ -10,8 +10,17 @@ import { saveAs } from 'file-saver';
 import BloggerService from '../services/BloggerService';
 import AuthService from '../services/AuthService';
 import Feedback from './Feedback';
+import AIAssistant from './AIAssistant';
+import AISelectionMenu from './AISelectionMenu';
 import i18n, { t } from '../services/I18nService';
-import { getStoredJson, setStoredValue } from '../utils/storage';
+import { getStoredJson, getStoredValue, setStoredValue } from '../utils/storage';
+import {
+  Base64UploadAdapterPlugin,
+  ImageSizeAttributesPlugin,
+  EDITOR_TOOLBAR,
+  EDITOR_IMAGE_CONFIG,
+  EDITOR_TABLE_CONFIG
+} from '../utils/ckeditorExtensions';
 
 /**
  * Componente do Editor de Posts
@@ -64,6 +73,11 @@ function PostEditor({ theme, toggleTheme }) {
   // Estado para mensagens de feedback
   const [feedback, setFeedback] = useState(null);
   const autoSaveDataRef = useRef({ postData, metadata, selectedBlog, postId });
+
+  // Assistente de IA
+  const [editorInstance, setEditorInstance] = useState(null);
+  const [showAIPanel, setShowAIPanel] = useState(() => getStoredValue('blogcraft_ai_panel_open') === 'true');
+  const draftCheckedRef = useRef(false);
 
   useEffect(() => {
     autoSaveDataRef.current = { postData, metadata, selectedBlog, postId };
@@ -126,6 +140,56 @@ function PostEditor({ theme, toggleTheme }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedBlog, postId]);
 
+  /**
+   * Ao criar um novo post: oferece a restauração do rascunho local
+   * (auto-guardado) ou aplica o template padrão das definições.
+   */
+  useEffect(() => {
+    if (draftCheckedRef.current || !selectedBlog || postId) return;
+    if (location.state && (location.state.title || location.state.content)) return;
+
+    draftCheckedRef.current = true;
+
+    const draftKey = `blogcraft_draft_${selectedBlog}_new`;
+    const draft = getStoredJson(draftKey, null);
+
+    if (draft && (draft.title || draft.content)) {
+      const savedAt = draft.savedAt ? new Date(draft.savedAt).toLocaleString() : '';
+      if (window.confirm(t('editor.draft.restoreConfirm', { time: savedAt }))) {
+        setPostData(prev => ({
+          ...prev,
+          title: draft.title || '',
+          content: draft.content || '',
+          labels: draft.labels || []
+        }));
+        if (draft.metadata) {
+          setMetadata(draft.metadata);
+        }
+        if (editorRef.current && draft.content) {
+          editorRef.current.setData(draft.content);
+        }
+        return;
+      }
+      localStorage.removeItem(draftKey);
+    }
+
+    // Sem rascunho: aplicar o template padrão definido nas Definições.
+    const settings = getStoredJson('blogcraft_settings', {});
+    if (settings.defaultTemplate) {
+      const savedTemplates = getStoredJson('blogcraft_templates', []);
+      const defaultTemplate = savedTemplates.find(
+        tpl => String(tpl.id) === String(settings.defaultTemplate)
+      );
+      if (defaultTemplate && defaultTemplate.content) {
+        setPostData(prev => (prev.content ? prev : { ...prev, content: defaultTemplate.content }));
+        if (editorRef.current) {
+          editorRef.current.setData(defaultTemplate.content);
+        }
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedBlog, postId]);
+
 
   /**
    * Auto-salva o post atual como rascunho
@@ -176,10 +240,13 @@ function PostEditor({ theme, toggleTheme }) {
       
       if (data.items) {
         setBlogs(data.items);
-        
-        // Se não houver blog selecionado, selecionar o primeiro
+
+        // Se não houver blog selecionado, usar o blog padrão das
+        // definições (quando existir) ou o primeiro da lista
         if (!selectedBlog && data.items.length > 0) {
-          setSelectedBlog(data.items[0].id);
+          const settings = getStoredJson('blogcraft_settings', {});
+          const preferred = data.items.find(blog => blog.id === settings.defaultBlogId);
+          setSelectedBlog((preferred || data.items[0]).id);
         }
       }
     } catch (error) {
@@ -406,6 +473,86 @@ function PostEditor({ theme, toggleTheme }) {
   };
 
   /**
+   * Insere um fragmento HTML no editor mantendo o histórico de undo.
+   * @param {string} html - Fragmento HTML a inserir
+   * @param {Object} [range] - Range do modelo a substituir (opcional)
+   */
+  const insertHtmlInEditor = (html, range = null) => {
+    const editor = editorRef.current;
+    if (!editor) return false;
+
+    const viewFragment = editor.data.processor.toView(html);
+    const modelFragment = editor.data.toModel(viewFragment);
+
+    if (range) {
+      editor.model.insertContent(modelFragment, range);
+    } else {
+      editor.model.insertContent(modelFragment);
+    }
+    return true;
+  };
+
+  /**
+   * Aplica uma ação devolvida pelo assistente de IA diretamente no
+   * artigo (documento completo, inserção, substituição da seleção ou
+   * título). As alterações passam pelo modelo do CKEditor, por isso
+   * podem ser desfeitas com Ctrl+Z.
+   */
+  const applyAIAction = (action) => {
+    const editor = editorRef.current;
+
+    switch (action.type) {
+      case 'set_title':
+        setPostData(prev => ({ ...prev, title: action.title }));
+        return true;
+
+      case 'replace_document': {
+        if (!editor) {
+          setPostData(prev => ({ ...prev, content: action.html }));
+          return true;
+        }
+        const root = editor.model.document.getRoot();
+        const range = editor.model.createRangeIn(root);
+        return insertHtmlInEditor(action.html, range);
+      }
+
+      case 'insert_html':
+      case 'replace_selection':
+        return insertHtmlInEditor(action.html);
+
+      default:
+        return false;
+    }
+  };
+
+  /**
+   * Devolve o HTML atualmente selecionado no editor (para dar contexto
+   * ao assistente de IA).
+   */
+  const getEditorSelectionHtml = () => {
+    const editor = editorRef.current;
+    if (!editor) return '';
+
+    try {
+      const selection = editor.model.document.selection;
+      if (selection.isCollapsed) return '';
+      return editor.data.stringify(editor.model.getSelectedContent(selection));
+    } catch {
+      return '';
+    }
+  };
+
+  /**
+   * Alterna o painel do assistente de IA
+   */
+  const toggleAIPanel = () => {
+    setShowAIPanel(prev => {
+      setStoredValue('blogcraft_ai_panel_open', String(!prev));
+      return !prev;
+    });
+  };
+
+  /**
    * Salva o post (como rascunho ou publicado)
    */
   const handleSavePost = async (publish = false) => {
@@ -561,26 +708,39 @@ function PostEditor({ theme, toggleTheme }) {
     
     reader.onload = (event) => {
       const fileContent = event.target.result;
-      
+
+      // Ficheiros .docx (e .doc modernos) são contentores ZIP binários
+      // que não podem ser interpretados como HTML no navegador.
+      if (typeof fileContent === 'string' && fileContent.startsWith('PK')) {
+        setFeedback({
+          type: 'error',
+          message: t('editor.errors.importBinary')
+        });
+        e.target.value = '';
+        return;
+      }
+
       // Tentar extrair título e conteúdo
       let title = '';
       let content = '';
-      
+
       if (file.name.endsWith('.txt')) {
         // Arquivo TXT - primeira linha como título, resto como conteúdo
         const lines = fileContent.split('\n');
         title = lines[0] || '';
-        content = lines.slice(1).join('\n');
-      } else if (file.name.endsWith('.doc') || file.name.endsWith('.docx') || file.name.endsWith('.html')) {
+        content = lines.slice(1)
+          .map(line => (line.trim() ? `<p>${line}</p>` : ''))
+          .join('');
+      } else {
         // Arquivo Word/HTML - tentar extrair conteúdo
         try {
           const parser = new DOMParser();
           const doc = parser.parseFromString(fileContent, 'text/html');
-          
+
           // Tentar obter o título
           const titleElement = doc.querySelector('title') || doc.querySelector('h1');
           title = titleElement ? titleElement.textContent : '';
-          
+
           // Obter o conteúdo do body
           const bodyElement = doc.querySelector('body');
           content = bodyElement ? bodyElement.innerHTML : fileContent;
@@ -589,25 +749,33 @@ function PostEditor({ theme, toggleTheme }) {
           content = fileContent;
         }
       }
-      
+
       setPostData(prev => ({
         ...prev,
         title: title || prev.title,
         content: content || prev.content
       }));
-      
+
       // Atualizar o editor com o novo conteúdo
-      if (editorRef.current) {
+      if (editorRef.current && content) {
         editorRef.current.setData(content);
       }
+      e.target.value = '';
     };
-    
-    if (file.name.endsWith('.txt') || file.name.endsWith('.html')) {
-      reader.readAsText(file);
-    } else {
-      reader.readAsDataURL(file);
-    }
+
+    reader.readAsText(file);
   };
+
+  // Contagem de palavras/caracteres do artigo (sem markup)
+  const plainText = postData.content
+    ? postData.content
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+    : '';
+  const wordCount = plainText ? plainText.split(' ').length : 0;
+  const charCount = plainText.length;
 
   /**
    * Render do componente
@@ -619,15 +787,23 @@ function PostEditor({ theme, toggleTheme }) {
         
         <div className="editor-actions">
           <button
+            className={`ai-toggle-button ${showAIPanel ? 'active' : ''}`}
+            onClick={toggleAIPanel}
+            title={t('ai.toggleTooltip')}
+          >
+            <span role="img" aria-label="AI">✨</span> {t('ai.toggle')}
+          </button>
+
+          <button
             className="save-draft-button"
             onClick={handleSaveAsDraft}
             disabled={saving}
           >
             {saving ? t('editor.saving.saving') : t('editor.buttons.saveDraft')}
           </button>
-          
-          <button 
-            className="publish-button" 
+
+          <button
+            className="publish-button"
             onClick={handlePublish}
             disabled={saving}
           >
@@ -647,7 +823,8 @@ function PostEditor({ theme, toggleTheme }) {
       {loading ? (
         <div className="loading">{t('common.loading')}</div>
       ) : (
-        <>
+        <div className={`editor-body ${showAIPanel ? 'with-ai' : ''}`}>
+        <div className="editor-main">
           <div className="blog-selector">
             <label>{t('editor.labels.blog')}</label>
             <select
@@ -796,52 +973,47 @@ function PostEditor({ theme, toggleTheme }) {
               onReady={editor => {
                 // Armazenar referência ao editor
                 editorRef.current = editor;
-                
+                setEditorInstance(editor);
+
                 // Configurações adicionais
                 editor.ui.view.editable.element.style.minHeight = '500px';
               }}
               config={{
-                toolbar: [
-                  'heading',
-                  '|',
-                  'bold', 'italic', 'strikethrough', 'underline',
-                  '|',
-                  'link', 'bulletedList', 'numberedList', 'todoList',
-                  '|',
-                  'indent', 'outdent',
-                  '|',
-                  'imageUpload', 'blockQuote', 'insertTable', 'mediaEmbed',
-                  '|',
-                  'undo', 'redo',
-                  '|',
-                  'fontBackgroundColor', 'fontColor',
-                  '|',
-                  'fontSize', 'fontFamily',
-                  '|',
-                  'alignment',
-                  '|',
-                  'horizontalLine'
-                ],
-                image: {
-                  // Configuração para upload de imagens
-                  toolbar: [
-                    'imageTextAlternative',
-                    'imageStyle:full',
-                    'imageStyle:side'
-                  ]
-                },
-                table: {
-                  contentToolbar: [
-                    'tableColumn', 'tableRow', 'mergeTableCells',
-                    'tableCellProperties', 'tableProperties'
-                  ]
-                },
-                  language: i18n.getLocale().split('-')[0]
-                }}
-              />
+                // Plugins adicionais: upload de imagens (base64) e
+                // preservação de largura/altura das imagens
+                extraPlugins: [Base64UploadAdapterPlugin, ImageSizeAttributesPlugin],
+                toolbar: EDITOR_TOOLBAR,
+                image: EDITOR_IMAGE_CONFIG,
+                table: EDITOR_TABLE_CONFIG,
+                language: i18n.getLocale().split('-')[0]
+              }}
+            />
           </div>
-        </>
+
+          <div className="editor-statusbar">
+            <span>{t('editor.stats.words', { count: wordCount })}</span>
+            <span>·</span>
+            <span>{t('editor.stats.characters', { count: charCount })}</span>
+          </div>
+        </div>
+
+        {showAIPanel && (
+          <AIAssistant
+            getTitle={() => autoSaveDataRef.current.postData.title}
+            getContent={() => autoSaveDataRef.current.postData.content}
+            getSelectionHtml={getEditorSelectionHtml}
+            applyAction={applyAIAction}
+            onClose={toggleAIPanel}
+          />
+        )}
+        </div>
       )}
+
+      <AISelectionMenu
+        editor={editorInstance}
+        getTitle={() => autoSaveDataRef.current.postData.title}
+        onFeedback={setFeedback}
+      />
       
       {/* Indicador de salvamento */}
       {saving && (

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -7,6 +7,7 @@ import BloggerService from '../services/BloggerService';
 // Importar o serviço de internacionalização
 import i18n, { LOCALES, t } from '../services/I18nService';
 import { getStoredJson } from '../utils/storage';
+import AIService, { AI_PROVIDERS, getAISettings, saveAISettings } from '../services/AIService';
 
 /**
  * Componente Settings - Configurações da aplicação
@@ -37,7 +38,12 @@ function Settings({ theme, toggleTheme }) {
     showDebugger: false
   });
   const [error, setError] = useState(null);
-  
+
+  // Definições do assistente de IA
+  const [aiSettings, setAISettings] = useState(getAISettings());
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [aiTestState, setAITestState] = useState({ status: 'idle', message: '' });
+
   // Carregar configurações e dados ao montar o componente
   useEffect(() => {
     loadSettings();
@@ -127,6 +133,38 @@ function Settings({ theme, toggleTheme }) {
   };
 
   /**
+   * Atualiza uma definição do assistente de IA
+   */
+  const handleAIChange = (field, value) => {
+    setAITestState({ status: 'idle', message: '' });
+    setAISettings(prev => {
+      if (field === 'apiKey') {
+        return { ...prev, apiKeys: { ...prev.apiKeys, [prev.provider]: value } };
+      }
+      if (field === 'model') {
+        return { ...prev, models: { ...prev.models, [prev.provider]: value } };
+      }
+      return { ...prev, [field]: value };
+    });
+  };
+
+  /**
+   * Testa a ligação ao fornecedor de IA com as definições atuais
+   */
+  const handleTestAI = async () => {
+    setAITestState({ status: 'testing', message: '' });
+    // Guardar primeiro para que o serviço use as definições atuais
+    saveAISettings(aiSettings);
+
+    try {
+      await AIService.testConnection();
+      setAITestState({ status: 'success', message: t('ai.settings.testSuccess') });
+    } catch (error) {
+      setAITestState({ status: 'error', message: error.message });
+    }
+  };
+
+  /**
    * Manipula a mudança de idioma
    */
   const handleLanguageChange = (e) => {
@@ -151,6 +189,9 @@ function Settings({ theme, toggleTheme }) {
           }
         })
       );
+
+      // Salvar definições do assistente de IA
+      saveAISettings(aiSettings);
 
       // Salvar idioma
       i18n.setLocale(language);
@@ -408,6 +449,109 @@ function Settings({ theme, toggleTheme }) {
                 <p className="setting-description">{t('settings.fields.languageDesc')}</p>
               </div>
             </div>
+            <div className="setting-group">
+              <h2>{t('ai.settings.section')}</h2>
+
+              <div className="setting-item">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={aiSettings.enabled}
+                    onChange={(e) => handleAIChange('enabled', e.target.checked)}
+                  />
+                  {t('ai.settings.enable')}
+                </label>
+                <p className="setting-description">{t('ai.settings.enableDesc')}</p>
+              </div>
+
+              {aiSettings.enabled && (
+                <>
+                  <div className="setting-item">
+                    <label htmlFor="aiProvider">{t('ai.settings.provider')}</label>
+                    <select
+                      id="aiProvider"
+                      value={aiSettings.provider}
+                      onChange={(e) => handleAIChange('provider', e.target.value)}
+                    >
+                      {Object.values(AI_PROVIDERS).map(provider => (
+                        <option key={provider.id} value={provider.id}>{provider.label}</option>
+                      ))}
+                    </select>
+                    <p className="setting-description">{t('ai.settings.providerDesc')}</p>
+                  </div>
+
+                  <div className="setting-item">
+                    <label htmlFor="aiApiKey">{t('ai.settings.apiKey')}</label>
+                    <div className="ai-key-row">
+                      <input
+                        id="aiApiKey"
+                        type={showApiKey ? 'text' : 'password'}
+                        autoComplete="off"
+                        value={aiSettings.apiKeys[aiSettings.provider] || ''}
+                        placeholder={AI_PROVIDERS[aiSettings.provider].keyPlaceholder}
+                        onChange={(e) => handleAIChange('apiKey', e.target.value)}
+                      />
+                      <button
+                        type="button"
+                        className="ai-key-toggle"
+                        onClick={() => setShowApiKey(prev => !prev)}
+                      >
+                        {showApiKey ? t('ai.settings.hideKey') : t('ai.settings.showKey')}
+                      </button>
+                    </div>
+                    <p className="setting-description">
+                      {t('ai.settings.apiKeyDesc')}{' '}
+                      <a
+                        href={AI_PROVIDERS[aiSettings.provider].keyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {t('ai.settings.getKey')}
+                      </a>
+                    </p>
+                  </div>
+
+                  <div className="setting-item">
+                    <label htmlFor="aiModel">{t('ai.settings.model')}</label>
+                    <select
+                      id="aiModel"
+                      value={aiSettings.models[aiSettings.provider] || ''}
+                      onChange={(e) => handleAIChange('model', e.target.value)}
+                    >
+                      <option value="">
+                        {t('ai.settings.defaultModel', { model: AI_PROVIDERS[aiSettings.provider].defaultModel })}
+                      </option>
+                      {AI_PROVIDERS[aiSettings.provider].models.map(model => (
+                        <option key={model} value={model}>{model}</option>
+                      ))}
+                    </select>
+                    <p className="setting-description">{t('ai.settings.modelDesc')}</p>
+                  </div>
+
+                  <div className="setting-item">
+                    <div className="ai-test-row">
+                      <button
+                        type="button"
+                        className="ai-test-button"
+                        onClick={handleTestAI}
+                        disabled={aiTestState.status === 'testing' || !(aiSettings.apiKeys[aiSettings.provider] || '').trim()}
+                      >
+                        {aiTestState.status === 'testing' ? t('ai.settings.testing') : t('ai.settings.testConnection')}
+                      </button>
+                      {aiTestState.status === 'success' && (
+                        <span className="ai-test-result success">✓ {aiTestState.message}</span>
+                      )}
+                      {aiTestState.status === 'error' && (
+                        <span className="ai-test-result error">✗ {aiTestState.message}</span>
+                      )}
+                    </div>
+                  </div>
+
+                  <p className="ai-security-note">{t('ai.settings.securityNote')}</p>
+                </>
+              )}
+            </div>
+
             <div className="setting-group">
               <h2>{t('settings.sections.debug')}</h2>
 

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -152,7 +152,84 @@ const translations = {
         selectBlog: 'Please select a blog before saving the post.',
         enterTitle: 'Please enter a title for the post.',
         loadBlogs: 'Unable to load your blogs. Please check your connection and try again.',
-        loadPost: 'Unable to load the post. Please check your connection and try again.'
+        loadPost: 'Unable to load the post. Please check your connection and try again.',
+        importBinary: 'This Word file is in a binary format that cannot be imported directly. In Word, save the document as "Web Page (.html)" or plain text and import that file.'
+      },
+      draft: {
+        restoreConfirm: 'An auto-saved draft from {time} was found. Do you want to restore it?'
+      },
+      stats: {
+        words: '{count} words',
+        characters: '{count} characters'
+      }
+    },
+
+    ai: {
+      toggle: 'AI Assistant',
+      toggleTooltip: 'Open the AI writing assistant (GPT, Gemini or Claude)',
+      chat: {
+        title: 'AI Assistant',
+        placeholder: 'Ask the AI to write, edit or illustrate your article...',
+        send: 'Send',
+        emptyState: 'Ask the AI to write a full article, rewrite sections, fix grammar, insert images, or anything else. Changes are applied directly in the editor and can be undone with Ctrl+Z.',
+        changesApplied: 'Changes applied to the article',
+        notConfigured: 'The AI assistant is not configured yet. Add your OpenAI (GPT), Google (Gemini) or Anthropic (Claude) API key in Settings to start using it.',
+        openSettings: 'Open AI Settings',
+        error: 'AI error: {message}'
+      },
+      quickActions: {
+        improve: 'Improve writing',
+        grammar: 'Fix grammar',
+        continue: 'Continue writing',
+        summarize: 'Add summary',
+        titles: 'Suggest title',
+        images: 'Suggest images'
+      },
+      quickPrompts: {
+        improve: 'Improve the writing of the whole article: make it clearer and more engaging while keeping the meaning, structure, language and images.',
+        grammar: 'Fix all grammar, spelling and punctuation mistakes in the article without changing its style, structure or language.',
+        continue: 'Continue writing the article from where it ends, keeping the same tone, language and formatting. Add one or two new paragraphs.',
+        summarize: 'Add a short introduction summary (2-3 sentences) at the top of the article, keeping its language.',
+        titles: 'Suggest a better title for this article and set it. Mention a couple of alternatives in your reply.',
+        images: 'Suggest where images would improve this article and insert placeholder images (https://placehold.co) with descriptive alt text and captions at those spots.'
+      },
+      selection: {
+        label: 'AI actions for the selection',
+        working: 'Rewriting selection...',
+        applied: 'Selection updated by the AI.',
+        askPlaceholder: 'Tell the AI what to do with the selection...'
+      },
+      selectionActions: {
+        improve: 'Improve',
+        grammar: 'Fix grammar',
+        shorten: 'Shorten',
+        expand: 'Expand',
+        ask: 'Ask AI'
+      },
+      selectionPrompts: {
+        improve: 'Improve this text: make it clearer and more engaging while keeping the meaning and language.',
+        grammar: 'Fix grammar, spelling and punctuation without changing the style or language.',
+        shorten: 'Make this text more concise while keeping all key information and the language.',
+        expand: 'Expand this text with more detail and examples, keeping the tone and language.'
+      },
+      settings: {
+        section: 'AI Assistant',
+        enable: 'Enable AI assistant',
+        enableDesc: 'Shows the AI assistant and selection tools in the post editor.',
+        provider: 'AI Provider:',
+        providerDesc: 'Choose which AI service to use with your own API key or subscription.',
+        apiKey: 'API Key:',
+        apiKeyDesc: 'Your personal API key for the selected provider.',
+        getKey: 'Get an API key',
+        showKey: 'Show',
+        hideKey: 'Hide',
+        model: 'Model:',
+        modelDesc: 'Model used for chat and text editing.',
+        defaultModel: 'Default ({model})',
+        testConnection: 'Test Connection',
+        testing: 'Testing...',
+        testSuccess: 'Connection working!',
+        securityNote: 'Your API key is stored only in this browser (localStorage) and sent directly to the AI provider. Requests may incur costs on your provider account. Do not use shared computers for storing keys.'
       }
     },
 

--- a/src/locales/pt-PT.js
+++ b/src/locales/pt-PT.js
@@ -152,7 +152,84 @@ const translations = {
         selectBlog: 'Por favor, selecione um blogue antes de guardar o artigo.',
         enterTitle: 'Por favor, insira um título para o artigo.',
         loadBlogs: 'Não foi possível carregar os seus blogues. Por favor, verifique a sua conexão e tente novamente.',
-        loadPost: 'Não foi possível carregar o artigo. Por favor, verifique a sua conexão e tente novamente.'
+        loadPost: 'Não foi possível carregar o artigo. Por favor, verifique a sua conexão e tente novamente.',
+        importBinary: 'Este ficheiro Word está num formato binário que não pode ser importado diretamente. No Word, guarde o documento como "Página Web (.html)" ou texto simples e importe esse ficheiro.'
+      },
+      draft: {
+        restoreConfirm: 'Foi encontrado um rascunho guardado automaticamente em {time}. Deseja restaurá-lo?'
+      },
+      stats: {
+        words: '{count} palavras',
+        characters: '{count} caracteres'
+      }
+    },
+
+    ai: {
+      toggle: 'Assistente IA',
+      toggleTooltip: 'Abrir o assistente de escrita com IA (GPT, Gemini ou Claude)',
+      chat: {
+        title: 'Assistente IA',
+        placeholder: 'Peça à IA para escrever, editar ou ilustrar o artigo...',
+        send: 'Enviar',
+        emptyState: 'Peça à IA para escrever um artigo completo, reescrever secções, corrigir a gramática, inserir imagens, ou qualquer outra coisa. As alterações são aplicadas diretamente no editor e podem ser desfeitas com Ctrl+Z.',
+        changesApplied: 'Alterações aplicadas ao artigo',
+        notConfigured: 'O assistente de IA ainda não está configurado. Adicione a sua chave de API da OpenAI (GPT), Google (Gemini) ou Anthropic (Claude) nas Definições para começar a usá-lo.',
+        openSettings: 'Abrir Definições de IA',
+        error: 'Erro de IA: {message}'
+      },
+      quickActions: {
+        improve: 'Melhorar escrita',
+        grammar: 'Corrigir gramática',
+        continue: 'Continuar a escrever',
+        summarize: 'Adicionar resumo',
+        titles: 'Sugerir título',
+        images: 'Sugerir imagens'
+      },
+      quickPrompts: {
+        improve: 'Melhora a escrita de todo o artigo: torna-o mais claro e cativante mantendo o significado, a estrutura, o idioma e as imagens.',
+        grammar: 'Corrige todos os erros de gramática, ortografia e pontuação do artigo sem alterar o estilo, a estrutura ou o idioma.',
+        continue: 'Continua a escrever o artigo a partir do ponto onde termina, mantendo o mesmo tom, idioma e formatação. Adiciona um ou dois parágrafos novos.',
+        summarize: 'Adiciona um pequeno resumo introdutório (2-3 frases) no início do artigo, mantendo o idioma.',
+        titles: 'Sugere um título melhor para este artigo e aplica-o. Menciona algumas alternativas na tua resposta.',
+        images: 'Sugere onde imagens melhorariam este artigo e insere imagens de exemplo (https://placehold.co) com texto alternativo descritivo e legendas nesses locais.'
+      },
+      selection: {
+        label: 'Ações de IA para a seleção',
+        working: 'A reescrever a seleção...',
+        applied: 'Seleção atualizada pela IA.',
+        askPlaceholder: 'Diga à IA o que fazer com a seleção...'
+      },
+      selectionActions: {
+        improve: 'Melhorar',
+        grammar: 'Corrigir',
+        shorten: 'Encurtar',
+        expand: 'Expandir',
+        ask: 'Pedir à IA'
+      },
+      selectionPrompts: {
+        improve: 'Melhora este texto: torna-o mais claro e cativante mantendo o significado e o idioma.',
+        grammar: 'Corrige a gramática, ortografia e pontuação sem alterar o estilo ou o idioma.',
+        shorten: 'Torna este texto mais conciso mantendo toda a informação essencial e o idioma.',
+        expand: 'Expande este texto com mais detalhe e exemplos, mantendo o tom e o idioma.'
+      },
+      settings: {
+        section: 'Assistente de IA',
+        enable: 'Ativar assistente de IA',
+        enableDesc: 'Mostra o assistente de IA e as ferramentas de seleção no editor de artigos.',
+        provider: 'Fornecedor de IA:',
+        providerDesc: 'Escolha o serviço de IA a usar com a sua própria chave de API ou subscrição.',
+        apiKey: 'Chave de API:',
+        apiKeyDesc: 'A sua chave de API pessoal para o fornecedor selecionado.',
+        getKey: 'Obter uma chave de API',
+        showKey: 'Mostrar',
+        hideKey: 'Ocultar',
+        model: 'Modelo:',
+        modelDesc: 'Modelo usado para o chat e edição de texto.',
+        defaultModel: 'Predefinido ({model})',
+        testConnection: 'Testar Ligação',
+        testing: 'A testar...',
+        testSuccess: 'Ligação a funcionar!',
+        securityNote: 'A sua chave de API é guardada apenas neste navegador (localStorage) e enviada diretamente para o fornecedor de IA. Os pedidos podem gerar custos na sua conta do fornecedor. Evite guardar chaves em computadores partilhados.'
       }
     },
 

--- a/src/services/AIService.js
+++ b/src/services/AIService.js
@@ -1,0 +1,443 @@
+/**
+ * AIService - Multi-provider AI integration
+ *
+ * Lets the user plug in their own API key (or subscription key) for
+ * OpenAI (GPT), Google (Gemini) or Anthropic (Claude) and talk to the
+ * model directly from the post editor.
+ *
+ * The service exposes:
+ * - Provider metadata (models, key format hints, docs links)
+ * - Settings persistence (stored locally in the browser only)
+ * - chat()               – free-form conversation with document context
+ * - transformSelection() – rewrite a selected HTML fragment
+ * - parseAssistantResponse() – parses the JSON action protocol
+ * - testConnection()     – small round-trip to validate credentials
+ */
+
+import { getStoredJson, setStoredValue } from '../utils/storage';
+
+const SETTINGS_KEY = 'blogcraft_ai_settings';
+const REQUEST_TIMEOUT = 90 * 1000;
+
+export const AI_PROVIDERS = {
+  openai: {
+    id: 'openai',
+    label: 'OpenAI (GPT)',
+    models: ['gpt-4o-mini', 'gpt-4o', 'gpt-4.1-mini', 'gpt-4.1'],
+    defaultModel: 'gpt-4o-mini',
+    keyPlaceholder: 'sk-...',
+    keyUrl: 'https://platform.openai.com/api-keys'
+  },
+  gemini: {
+    id: 'gemini',
+    label: 'Google (Gemini)',
+    models: ['gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-2.0-flash'],
+    defaultModel: 'gemini-2.5-flash',
+    keyPlaceholder: 'AIza...',
+    keyUrl: 'https://aistudio.google.com/app/apikey'
+  },
+  anthropic: {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    models: ['claude-sonnet-4-5', 'claude-haiku-4-5', 'claude-opus-4-1'],
+    defaultModel: 'claude-sonnet-4-5',
+    keyPlaceholder: 'sk-ant-...',
+    keyUrl: 'https://console.anthropic.com/settings/keys'
+  }
+};
+
+const DEFAULT_SETTINGS = {
+  enabled: false,
+  provider: 'openai',
+  // One key per provider so switching providers does not lose keys.
+  apiKeys: { openai: '', gemini: '', anthropic: '' },
+  // Empty model means "use the provider default".
+  models: { openai: '', gemini: '', anthropic: '' }
+};
+
+export const getAISettings = () => {
+  const stored = getStoredJson(SETTINGS_KEY, {});
+  return {
+    ...DEFAULT_SETTINGS,
+    ...stored,
+    apiKeys: { ...DEFAULT_SETTINGS.apiKeys, ...(stored.apiKeys || {}) },
+    models: { ...DEFAULT_SETTINGS.models, ...(stored.models || {}) }
+  };
+};
+
+export const saveAISettings = (settings) => {
+  const merged = { ...getAISettings(), ...settings };
+  setStoredValue(SETTINGS_KEY, JSON.stringify(merged));
+  window.dispatchEvent(new Event('blogcraft_ai_settings_updated'));
+  return merged;
+};
+
+export const getActiveProvider = (settings = getAISettings()) => {
+  return AI_PROVIDERS[settings.provider] || AI_PROVIDERS.openai;
+};
+
+export const getActiveModel = (settings = getAISettings()) => {
+  const provider = getActiveProvider(settings);
+  return (settings.models && settings.models[provider.id]) || provider.defaultModel;
+};
+
+export const getActiveApiKey = (settings = getAISettings()) => {
+  const provider = getActiveProvider(settings);
+  return ((settings.apiKeys && settings.apiKeys[provider.id]) || '').trim();
+};
+
+export const isAIConfigured = (settings = getAISettings()) => {
+  return !!(settings.enabled && getActiveApiKey(settings));
+};
+
+/**
+ * System prompt for the editor assistant. The model answers with a JSON
+ * envelope so BlogCraft can apply edits directly inside CKEditor.
+ */
+const buildAssistantSystemPrompt = ({ locale }) => `You are BlogCraft's writing assistant, embedded in a rich-text editor for Blogger posts.
+You help the user write, edit and illustrate blog articles.
+
+Always answer with a SINGLE valid JSON object (no markdown fences, no text outside the JSON):
+{
+  "reply": "<short conversational answer for the chat panel>",
+  "actions": [ ...zero or more of the actions below... ]
+}
+
+Available actions:
+- {"type": "replace_document", "html": "<full new article body HTML>"} — rewrite the whole article.
+- {"type": "insert_html", "html": "<HTML fragment>"} — insert content at the user's cursor (or at the end).
+- {"type": "replace_selection", "html": "<HTML fragment>"} — replace the text the user currently has selected. Only use when a selection is provided.
+- {"type": "set_title", "title": "<new post title>"} — change the post title.
+
+HTML rules for article content:
+- Use clean semantic HTML: <h2>/<h3> for sections, <p>, <ul>/<ol>, <blockquote>, <table>, <a>, <strong>, <i>.
+- Images: <figure class="image"><img src="URL" alt="description" width="600"><figcaption>optional caption</figcaption></figure>
+- Image position: add one class to the <figure> — "image-style-align-left", "image-style-align-center", "image-style-align-right", or "image-style-side" (floated right sidebar image). Resize with the width attribute (pixels).
+- Only reference image URLs the user gave you, images already present in the article, or clearly-labelled placeholders such as https://placehold.co/800x400.
+- Never include <html>, <head>, <body> or <script> tags.
+
+Reply in the user's language (interface locale: ${locale}).
+When the user only asks a question, return "actions": [].`;
+
+const SELECTION_SYSTEM_PROMPT = `You rewrite fragments of a blog article.
+You receive an HTML fragment and an instruction.
+Return ONLY the rewritten HTML fragment. No JSON, no markdown fences, no explanations.
+Keep the same language as the fragment unless asked otherwise, and keep inline formatting (links, bold, images) unless the instruction says to change it.`;
+
+/**
+ * Strips markdown code fences the models sometimes add despite instructions.
+ */
+export const stripCodeFences = (text) => {
+  if (!text) return '';
+  let out = text.trim();
+  const fence = out.match(/^```[a-zA-Z]*\s*([\s\S]*?)\s*```$/);
+  if (fence) out = fence[1].trim();
+  return out;
+};
+
+/**
+ * Parses the assistant JSON envelope. Falls back to a plain-text reply
+ * when the model did not follow the protocol.
+ */
+export const parseAssistantResponse = (text) => {
+  const cleaned = stripCodeFences(text);
+
+  let candidate = cleaned;
+  // Some models wrap the JSON in prose; extract the outermost object.
+  if (!candidate.startsWith('{')) {
+    const start = candidate.indexOf('{');
+    const end = candidate.lastIndexOf('}');
+    if (start !== -1 && end > start) {
+      candidate = candidate.slice(start, end + 1);
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(candidate);
+    if (parsed && typeof parsed === 'object' && ('reply' in parsed || 'actions' in parsed)) {
+      const actions = Array.isArray(parsed.actions) ? parsed.actions.filter(isValidAction) : [];
+      return { reply: typeof parsed.reply === 'string' ? parsed.reply : '', actions };
+    }
+  } catch {
+    // Not JSON – treat the full text as a conversational reply.
+  }
+
+  return { reply: cleaned, actions: [] };
+};
+
+const isValidAction = (action) => {
+  if (!action || typeof action !== 'object') return false;
+  switch (action.type) {
+    case 'replace_document':
+    case 'insert_html':
+    case 'replace_selection':
+      return typeof action.html === 'string' && action.html.length > 0;
+    case 'set_title':
+      return typeof action.title === 'string';
+    default:
+      return false;
+  }
+};
+
+/**
+ * Removes obviously dangerous markup from model-generated HTML before it
+ * reaches the editor (defence in depth – CKEditor filters too).
+ */
+export const sanitizeAIHtml = (html) => {
+  if (!html) return '';
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<(iframe|object|embed|form)[\s\S]*?<\/\1>/gi, '')
+    .replace(/\son\w+\s*=\s*"[^"]*"/gi, '')
+    .replace(/\son\w+\s*=\s*'[^']*'/gi, '')
+    .replace(/javascript:/gi, '');
+};
+
+const MAX_CONTEXT_HTML = 60000;
+
+const truncate = (text, max) => {
+  if (!text || text.length <= max) return text || '';
+  return `${text.slice(0, max)}\n<!-- [content truncated] -->`;
+};
+
+/**
+ * Builds the user message with document context for the chat assistant.
+ */
+export const buildEditorContextMessage = ({ title, html, selectionHtml, userMessage }) => {
+  const parts = [
+    `POST TITLE: ${title || '(untitled)'}`,
+    `CURRENT ARTICLE HTML:\n${truncate(html, MAX_CONTEXT_HTML) || '(empty)'}`
+  ];
+  if (selectionHtml) {
+    parts.push(`CURRENTLY SELECTED FRAGMENT:\n${truncate(selectionHtml, 8000)}`);
+  }
+  parts.push(`USER REQUEST:\n${userMessage}`);
+  return parts.join('\n\n---\n\n');
+};
+
+/* ------------------------------------------------------------------ */
+/* Provider transports                                                  */
+/* ------------------------------------------------------------------ */
+
+const fetchWithTimeout = async (url, options) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error('AI request timed out. Please try again.');
+    }
+    throw new Error('Could not reach the AI provider. Check your connection.');
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const readErrorMessage = async (response) => {
+  let detail = '';
+  try {
+    const data = await response.json();
+    detail = data?.error?.message || data?.message || '';
+  } catch {
+    // ignore body parse failures
+  }
+  if (response.status === 401 || response.status === 403) {
+    return `The AI provider rejected the API key (${response.status}). ${detail}`.trim();
+  }
+  if (response.status === 429) {
+    return `AI rate limit or quota exceeded (429). ${detail}`.trim();
+  }
+  return `AI request failed (${response.status}). ${detail}`.trim();
+};
+
+const callOpenAI = async ({ apiKey, model, system, messages, maxTokens }) => {
+  const response = await fetchWithTimeout('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model,
+      max_completion_tokens: maxTokens,
+      messages: [
+        { role: 'system', content: system },
+        ...messages.map(m => ({ role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content }))
+      ]
+    })
+  });
+
+  if (!response.ok) throw new Error(await readErrorMessage(response));
+  const data = await response.json();
+  const text = data?.choices?.[0]?.message?.content;
+  if (!text) throw new Error('The AI provider returned an empty response.');
+  return text;
+};
+
+const callGemini = async ({ apiKey, model, system, messages, maxTokens }) => {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`;
+  const response = await fetchWithTimeout(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': apiKey
+    },
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: system }] },
+      contents: messages.map(m => ({
+        role: m.role === 'assistant' ? 'model' : 'user',
+        parts: [{ text: m.content }]
+      })),
+      generationConfig: { maxOutputTokens: maxTokens }
+    })
+  });
+
+  if (!response.ok) throw new Error(await readErrorMessage(response));
+  const data = await response.json();
+  const text = data?.candidates?.[0]?.content?.parts?.map(p => p.text || '').join('');
+  if (!text) throw new Error('The AI provider returned an empty response.');
+  return text;
+};
+
+const callAnthropic = async ({ apiKey, model, system, messages, maxTokens }) => {
+  const response = await fetchWithTimeout('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      // Required for calling the Anthropic API from a browser with a user-supplied key.
+      'anthropic-dangerous-direct-browser-access': 'true'
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: maxTokens,
+      system,
+      messages: messages.map(m => ({ role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content }))
+    })
+  });
+
+  if (!response.ok) throw new Error(await readErrorMessage(response));
+  const data = await response.json();
+  const text = (data?.content || []).filter(b => b.type === 'text').map(b => b.text).join('');
+  if (!text) throw new Error('The AI provider returned an empty response.');
+  return text;
+};
+
+const TRANSPORTS = {
+  openai: callOpenAI,
+  gemini: callGemini,
+  anthropic: callAnthropic
+};
+
+/**
+ * Low-level completion call.
+ * @param {Object} params
+ * @param {string} params.system - system prompt
+ * @param {Array<{role: 'user'|'assistant', content: string}>} params.messages
+ * @param {number} [params.maxTokens]
+ * @returns {Promise<string>} raw model text
+ */
+export const complete = async ({ system, messages, maxTokens = 8192 }) => {
+  const settings = getAISettings();
+
+  if (!settings.enabled) {
+    throw new Error('AI assistant is disabled. Enable it in Settings.');
+  }
+
+  const apiKey = getActiveApiKey(settings);
+  if (!apiKey) {
+    throw new Error('No API key configured for the selected AI provider. Add one in Settings.');
+  }
+
+  const provider = getActiveProvider(settings);
+  const transport = TRANSPORTS[provider.id];
+  const model = getActiveModel(settings);
+
+  return transport({ apiKey, model, system, messages, maxTokens });
+};
+
+/**
+ * Chat with the editor assistant. Returns { reply, actions }.
+ */
+export const chat = async ({ history = [], userMessage, title, html, selectionHtml, locale = 'en-US' }) => {
+  const contextMessage = buildEditorContextMessage({ title, html, selectionHtml, userMessage });
+
+  // Older turns are sent as plain text (no document snapshots) to keep
+  // requests small; the current turn carries the fresh article HTML.
+  const messages = [
+    ...history.slice(-8).map(m => ({ role: m.role, content: m.content })),
+    { role: 'user', content: contextMessage }
+  ];
+
+  const raw = await complete({
+    system: buildAssistantSystemPrompt({ locale }),
+    messages
+  });
+
+  const parsed = parseAssistantResponse(raw);
+  parsed.actions = parsed.actions.map(action => (
+    action.html ? { ...action, html: sanitizeAIHtml(action.html) } : action
+  ));
+  return parsed;
+};
+
+/**
+ * Rewrites a selected HTML fragment following an instruction.
+ * Returns the replacement HTML.
+ */
+export const transformSelection = async ({ selectionHtml, instruction, title, locale = 'en-US' }) => {
+  const raw = await complete({
+    system: SELECTION_SYSTEM_PROMPT,
+    messages: [{
+      role: 'user',
+      content: [
+        `Interface locale: ${locale}`,
+        `Article title: ${title || '(untitled)'}`,
+        `Instruction: ${instruction}`,
+        `Fragment to rewrite:\n${selectionHtml}`
+      ].join('\n\n')
+    }],
+    maxTokens: 4096
+  });
+
+  const html = sanitizeAIHtml(stripCodeFences(raw));
+  if (!html.trim()) {
+    throw new Error('The AI provider returned an empty response.');
+  }
+  return html;
+};
+
+/**
+ * Validates the configured provider/key with a minimal request.
+ */
+export const testConnection = async () => {
+  const raw = await complete({
+    system: 'You are a connectivity test. Answer with the single word: OK',
+    messages: [{ role: 'user', content: 'ping' }],
+    maxTokens: 20
+  });
+  return raw.trim();
+};
+
+const AIService = {
+  AI_PROVIDERS,
+  getAISettings,
+  saveAISettings,
+  getActiveProvider,
+  getActiveModel,
+  getActiveApiKey,
+  isAIConfigured,
+  parseAssistantResponse,
+  stripCodeFences,
+  sanitizeAIHtml,
+  buildEditorContextMessage,
+  complete,
+  chat,
+  transformSelection,
+  testConnection
+};
+
+export default AIService;

--- a/src/services/AIService.test.js
+++ b/src/services/AIService.test.js
@@ -1,0 +1,263 @@
+import AIService, {
+  AI_PROVIDERS,
+  getAISettings,
+  saveAISettings,
+  getActiveModel,
+  getActiveApiKey,
+  isAIConfigured,
+  parseAssistantResponse,
+  stripCodeFences,
+  sanitizeAIHtml,
+  buildEditorContextMessage
+} from './AIService';
+
+describe('AIService settings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('returns defaults when nothing is stored', () => {
+    const settings = getAISettings();
+    expect(settings.enabled).toBe(false);
+    expect(settings.provider).toBe('openai');
+    expect(settings.apiKeys).toEqual({ openai: '', gemini: '', anthropic: '' });
+  });
+
+  test('saves and merges settings per provider', () => {
+    saveAISettings({ enabled: true, provider: 'anthropic', apiKeys: { ...getAISettings().apiKeys, anthropic: 'sk-ant-test' } });
+
+    const settings = getAISettings();
+    expect(settings.enabled).toBe(true);
+    expect(settings.provider).toBe('anthropic');
+    expect(getActiveApiKey(settings)).toBe('sk-ant-test');
+    expect(isAIConfigured(settings)).toBe(true);
+
+    // Switching provider keeps the other provider's key.
+    saveAISettings({ provider: 'openai' });
+    const updated = getAISettings();
+    expect(updated.apiKeys.anthropic).toBe('sk-ant-test');
+    expect(isAIConfigured(updated)).toBe(false); // no OpenAI key yet
+  });
+
+  test('uses provider default model unless overridden', () => {
+    saveAISettings({ provider: 'gemini' });
+    expect(getActiveModel(getAISettings())).toBe(AI_PROVIDERS.gemini.defaultModel);
+
+    saveAISettings({ models: { ...getAISettings().models, gemini: 'gemini-2.5-pro' } });
+    expect(getActiveModel(getAISettings())).toBe('gemini-2.5-pro');
+  });
+});
+
+describe('parseAssistantResponse', () => {
+  test('parses a plain JSON envelope', () => {
+    const result = parseAssistantResponse('{"reply":"Done","actions":[{"type":"set_title","title":"Hello"}]}');
+    expect(result.reply).toBe('Done');
+    expect(result.actions).toEqual([{ type: 'set_title', title: 'Hello' }]);
+  });
+
+  test('parses JSON wrapped in markdown fences', () => {
+    const raw = '```json\n{"reply":"ok","actions":[{"type":"insert_html","html":"<p>hi</p>"}]}\n```';
+    const result = parseAssistantResponse(raw);
+    expect(result.reply).toBe('ok');
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0].type).toBe('insert_html');
+  });
+
+  test('extracts JSON embedded in prose', () => {
+    const raw = 'Here you go: {"reply":"done","actions":[]} hope it helps';
+    const result = parseAssistantResponse(raw);
+    expect(result.reply).toBe('done');
+    expect(result.actions).toEqual([]);
+  });
+
+  test('falls back to plain text replies', () => {
+    const result = parseAssistantResponse('Just a normal answer without JSON.');
+    expect(result.reply).toBe('Just a normal answer without JSON.');
+    expect(result.actions).toEqual([]);
+  });
+
+  test('filters out malformed actions', () => {
+    const raw = JSON.stringify({
+      reply: 'ok',
+      actions: [
+        { type: 'insert_html' }, // missing html
+        { type: 'unknown', html: '<p>x</p>' },
+        { type: 'replace_document', html: '<p>valid</p>' },
+        'not-an-object'
+      ]
+    });
+    const result = parseAssistantResponse(raw);
+    expect(result.actions).toEqual([{ type: 'replace_document', html: '<p>valid</p>' }]);
+  });
+});
+
+describe('sanitizeAIHtml', () => {
+  test('removes scripts, event handlers and javascript URLs', () => {
+    const dirty = '<p onclick="evil()">Hi</p><script>alert(1)</script><a href="javascript:x()">link</a>';
+    const clean = sanitizeAIHtml(dirty);
+    expect(clean).not.toContain('<script');
+    expect(clean).not.toContain('onclick');
+    expect(clean).not.toContain('javascript:');
+    expect(clean).toContain('<p');
+  });
+
+  test('keeps image markup with size and alignment', () => {
+    const html = '<figure class="image image-style-align-right"><img src="https://example.com/a.png" width="320" alt="x"></figure>';
+    expect(sanitizeAIHtml(html)).toBe(html);
+  });
+});
+
+describe('stripCodeFences', () => {
+  test('strips fenced blocks and trims', () => {
+    expect(stripCodeFences('```html\n<p>a</p>\n```')).toBe('<p>a</p>');
+    expect(stripCodeFences('  <p>b</p> ')).toBe('<p>b</p>');
+  });
+});
+
+describe('buildEditorContextMessage', () => {
+  test('includes title, article and selection', () => {
+    const message = buildEditorContextMessage({
+      title: 'My Post',
+      html: '<p>Body</p>',
+      selectionHtml: '<p>Sel</p>',
+      userMessage: 'Fix it'
+    });
+    expect(message).toContain('My Post');
+    expect(message).toContain('<p>Body</p>');
+    expect(message).toContain('<p>Sel</p>');
+    expect(message).toContain('Fix it');
+  });
+});
+
+describe('provider transports', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const configure = (provider, key) => {
+    saveAISettings({
+      enabled: true,
+      provider,
+      apiKeys: { ...getAISettings().apiKeys, [provider]: key }
+    });
+  };
+
+  test('complete() rejects when the assistant is disabled', async () => {
+    await expect(AIService.complete({ system: 's', messages: [] }))
+      .rejects.toThrow(/disabled/i);
+  });
+
+  test('complete() rejects when no key is configured', async () => {
+    saveAISettings({ enabled: true, provider: 'openai' });
+    await expect(AIService.complete({ system: 's', messages: [] }))
+      .rejects.toThrow(/API key/i);
+  });
+
+  test('calls OpenAI with the expected payload', async () => {
+    configure('openai', 'sk-test');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'hello' } }] })
+    });
+
+    const text = await AIService.complete({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'hi' }]
+    });
+
+    expect(text).toBe('hello');
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toContain('api.openai.com');
+    expect(options.headers.Authorization).toBe('Bearer sk-test');
+    const body = JSON.parse(options.body);
+    expect(body.model).toBe(AI_PROVIDERS.openai.defaultModel);
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'sys' });
+  });
+
+  test('calls Gemini with the expected payload', async () => {
+    configure('gemini', 'AIza-test');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: 'oi' }] } }] })
+    });
+
+    const text = await AIService.complete({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'hi' }]
+    });
+
+    expect(text).toBe('oi');
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toContain('generativelanguage.googleapis.com');
+    expect(url).toContain(AI_PROVIDERS.gemini.defaultModel);
+    expect(options.headers['x-goog-api-key']).toBe('AIza-test');
+    const body = JSON.parse(options.body);
+    expect(body.systemInstruction.parts[0].text).toBe('sys');
+  });
+
+  test('calls Anthropic with the expected payload', async () => {
+    configure('anthropic', 'sk-ant-test');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [{ type: 'text', text: 'olá' }] })
+    });
+
+    const text = await AIService.complete({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'hi' }]
+    });
+
+    expect(text).toBe('olá');
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toContain('api.anthropic.com');
+    expect(options.headers['x-api-key']).toBe('sk-ant-test');
+    expect(options.headers['anthropic-version']).toBeTruthy();
+    const body = JSON.parse(options.body);
+    expect(body.system).toBe('sys');
+    expect(body.model).toBe(AI_PROVIDERS.anthropic.defaultModel);
+  });
+
+  test('maps HTTP errors to readable messages', async () => {
+    configure('openai', 'sk-bad');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { message: 'Invalid API key' } })
+    });
+
+    await expect(AIService.complete({ system: 's', messages: [] }))
+      .rejects.toThrow(/rejected the API key/i);
+  });
+
+  test('chat() sanitizes HTML in returned actions', async () => {
+    configure('openai', 'sk-test');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              reply: 'done',
+              actions: [{ type: 'insert_html', html: '<p>ok</p><script>evil()</script>' }]
+            })
+          }
+        }]
+      })
+    });
+
+    const result = await AIService.chat({
+      userMessage: 'write',
+      title: 't',
+      html: '<p>a</p>'
+    });
+
+    expect(result.reply).toBe('done');
+    expect(result.actions[0].html).toBe('<p>ok</p>');
+  });
+});

--- a/src/styles/ai.css
+++ b/src/styles/ai.css
@@ -1,0 +1,431 @@
+/* Estilos do Assistente de IA (painel de chat, menu de seleção, definições) */
+
+/* ---- Layout do editor com painel de IA ---- */
+.editor-body {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.editor-body .editor-main {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---- Botão de alternância na barra do editor ---- */
+.ai-toggle-button {
+  background: linear-gradient(135deg, #7c3aed, #2563eb);
+  color: white;
+  padding: 10px 18px;
+  border: none;
+}
+
+.ai-toggle-button:hover {
+  filter: brightness(1.1);
+}
+
+.ai-toggle-button.active {
+  box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.45);
+}
+
+/* ---- Barra de estado do editor (contagem de palavras) ---- */
+.editor-statusbar {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 8px 4px 0;
+  font-size: 0.85rem;
+  opacity: 0.65;
+}
+
+/* ---- Painel de chat ---- */
+.ai-panel {
+  width: 340px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  border: 1px solid;
+  overflow: hidden;
+  position: sticky;
+  top: 20px;
+  max-height: calc(100vh - 40px);
+  min-height: 480px;
+}
+
+.light .ai-panel {
+  background-color: var(--card-light);
+  border-color: var(--border-light);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+}
+
+.dark .ai-panel {
+  background-color: var(--card-dark);
+  border-color: var(--border-dark);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.ai-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.12), rgba(37, 99, 235, 0.12));
+}
+
+.light .ai-panel-header {
+  border-color: var(--border-light);
+}
+
+.dark .ai-panel-header {
+  border-color: var(--border-dark);
+}
+
+.ai-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ai-panel-title .ai-spark {
+  font-size: 1.3rem;
+}
+
+.ai-model-badge {
+  display: block;
+  font-size: 0.72rem;
+  opacity: 0.65;
+  margin-top: 2px;
+}
+
+.ai-close-button {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  min-height: auto;
+  padding: 4px 10px;
+  color: inherit;
+  opacity: 0.7;
+}
+
+.ai-close-button:hover {
+  opacity: 1;
+  transform: none;
+}
+
+.ai-not-configured {
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  text-align: center;
+}
+
+.ai-settings-link {
+  display: inline-block;
+  padding: 10px 18px;
+  border-radius: 6px;
+  background-color: var(--primary-color);
+  color: white !important;
+  font-weight: 600;
+}
+
+.ai-settings-link:hover {
+  background-color: var(--primary-hover);
+}
+
+/* ---- Mensagens ---- */
+.ai-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ai-empty-state {
+  opacity: 0.6;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 24px 12px;
+}
+
+.ai-message {
+  max-width: 90%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ai-message.user {
+  align-self: flex-end;
+  background-color: var(--primary-color);
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+
+.ai-message.assistant {
+  align-self: flex-start;
+  border-bottom-left-radius: 4px;
+}
+
+.light .ai-message.assistant {
+  background-color: var(--surface-light);
+}
+
+.dark .ai-message.assistant {
+  background-color: var(--surface-dark);
+}
+
+.ai-message.error {
+  border: 1px solid var(--danger-color);
+  color: var(--danger-color);
+  background-color: rgba(220, 38, 38, 0.08);
+}
+
+.ai-applied-badge {
+  display: block;
+  margin-top: 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--secondary-color);
+}
+
+/* Indicador "a escrever" */
+.ai-typing {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.ai-typing i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: currentColor;
+  opacity: 0.5;
+  animation: ai-typing-bounce 1.2s infinite;
+}
+
+.ai-typing i:nth-child(2) { animation-delay: 0.15s; }
+.ai-typing i:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes ai-typing-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+  30% { transform: translateY(-4px); opacity: 1; }
+}
+
+/* ---- Ações rápidas ---- */
+.ai-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 14px;
+  border-top: 1px solid;
+}
+
+.light .ai-quick-actions { border-color: var(--border-light); }
+.dark .ai-quick-actions { border-color: var(--border-dark); }
+
+.ai-quick-button {
+  font-size: 0.78rem;
+  min-height: 30px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid;
+  background: transparent;
+  color: inherit;
+  font-weight: 500;
+}
+
+.light .ai-quick-button { border-color: var(--border-light); }
+.dark .ai-quick-button { border-color: var(--border-dark); }
+
+.ai-quick-button:hover {
+  border-color: var(--primary-color);
+  background-color: rgba(37, 99, 235, 0.1);
+}
+
+/* ---- Entrada de mensagem ---- */
+.ai-input-row {
+  display: flex;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid;
+}
+
+.light .ai-input-row { border-color: var(--border-light); }
+.dark .ai-input-row { border-color: var(--border-dark); }
+
+.ai-input-row textarea {
+  flex: 1;
+  resize: none;
+  font-size: 0.9rem;
+}
+
+.ai-send-button {
+  align-self: flex-end;
+  background-color: var(--primary-color);
+  color: white;
+  padding: 8px 16px;
+}
+
+.ai-send-button:hover:not(:disabled) {
+  background-color: var(--primary-hover);
+}
+
+/* ---- Menu flutuante de seleção ---- */
+.ai-selection-menu {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px;
+  border-radius: 10px;
+  border: 1px solid;
+  animation: fadeIn 0.15s ease-in-out;
+}
+
+.light .ai-selection-menu {
+  background-color: white;
+  border-color: var(--border-light);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+}
+
+.dark .ai-selection-menu {
+  background-color: #2f3238;
+  border-color: var(--border-dark);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.ai-selection-button {
+  font-size: 0.8rem;
+  min-height: 30px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.ai-selection-button:hover {
+  background-color: rgba(37, 99, 235, 0.12);
+  transform: none;
+}
+
+.ai-selection-button.ask {
+  color: #7c3aed;
+  font-weight: 600;
+}
+
+.dark .ai-selection-button.ask {
+  color: #b794f6;
+}
+
+.ai-selection-ask {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.ai-selection-ask input {
+  width: 240px;
+  font-size: 0.85rem;
+  padding: 6px 10px;
+}
+
+.ai-selection-ask button {
+  min-height: 32px;
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  background-color: var(--primary-color);
+  color: white;
+}
+
+.ai-selection-busy {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+/* ---- Definições de IA ---- */
+.ai-key-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ai-key-row input {
+  flex: 1;
+}
+
+.ai-key-row .ai-key-toggle {
+  min-height: 38px;
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px solid;
+  color: inherit;
+}
+
+.light .ai-key-row .ai-key-toggle { border-color: var(--border-light); }
+.dark .ai-key-row .ai-key-toggle { border-color: var(--border-dark); }
+
+.ai-test-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ai-test-button {
+  background-color: transparent;
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+}
+
+.ai-test-button:hover:not(:disabled) {
+  background-color: rgba(37, 99, 235, 0.1);
+}
+
+.ai-test-result {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.ai-test-result.success { color: var(--secondary-color); }
+.ai-test-result.error { color: var(--danger-color); }
+
+.ai-security-note {
+  font-size: 0.82rem;
+  opacity: 0.7;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border-left: 3px solid var(--accent-color);
+  background-color: rgba(245, 158, 11, 0.08);
+}
+
+/* ---- Responsividade ---- */
+@media (max-width: 1180px) {
+  .editor-body {
+    flex-direction: column;
+  }
+
+  .editor-body .ai-panel {
+    width: 100%;
+    position: static;
+    max-height: 60vh;
+    min-height: 380px;
+  }
+}

--- a/src/utils/ckeditorExtensions.js
+++ b/src/utils/ckeditorExtensions.js
@@ -1,0 +1,170 @@
+/**
+ * Runtime extensions for the prebuilt CKEditor 5 classic build.
+ *
+ * The classic build does not ship an upload adapter nor image resize
+ * support. These lightweight plugins close both gaps so that:
+ * - users can insert images from disk (embedded as base64 data URLs);
+ * - width/height attributes on images survive editing (needed so the
+ *   AI assistant – and imported content – can size images).
+ */
+
+/**
+ * Upload adapter that inlines picked files as base64 data URLs.
+ * Blogger accepts data URLs in post HTML, and this keeps BlogCraft
+ * free of any server-side upload dependency.
+ */
+class Base64UploadAdapter {
+  constructor(loader) {
+    this.loader = loader;
+    this.reader = null;
+  }
+
+  upload() {
+    return this.loader.file.then(file => new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      this.reader = reader;
+
+      reader.onload = () => resolve({ default: reader.result });
+      reader.onerror = error => reject(error);
+      reader.onabort = () => reject(new Error('Upload aborted'));
+
+      reader.readAsDataURL(file);
+    }));
+  }
+
+  abort() {
+    if (this.reader) {
+      this.reader.abort();
+    }
+  }
+}
+
+export function Base64UploadAdapterPlugin(editor) {
+  editor.plugins.get('FileRepository').createUploadAdapter = loader => new Base64UploadAdapter(loader);
+}
+
+const SIZE_ATTRIBUTES = ['width', 'height'];
+const IMAGE_MODELS = ['imageBlock', 'imageInline'];
+
+/**
+ * Preserves width/height attributes on <img> elements. Without this the
+ * classic build's schema silently strips them on load/paste, which would
+ * undo any image resizing done by the AI assistant.
+ */
+export function ImageSizeAttributesPlugin(editor) {
+  // Function plugins are constructed before the built-in features run
+  // their init(), i.e. before `imageBlock`/`imageInline` exist in the
+  // schema. Defer the setup until right before the first data load.
+  editor.data.on('init', () => setupImageSizeAttributes(editor), { priority: 'high' });
+}
+
+function setupImageSizeAttributes(editor) {
+  const schema = editor.model.schema;
+
+  for (const model of IMAGE_MODELS) {
+    if (schema.isRegistered(model)) {
+      schema.extend(model, { allowAttributes: SIZE_ATTRIBUTES });
+    }
+  }
+
+  editor.conversion.for('upcast').add(dispatcher => {
+    const copySizeAttributes = (data, conversionApi, viewImage) => {
+      if (!data.modelRange || !viewImage) return;
+
+      const modelImage = data.modelRange.start.nodeAfter || data.modelRange.start.parent;
+      if (!modelImage || !IMAGE_MODELS.includes(modelImage.name)) return;
+
+      for (const attribute of SIZE_ATTRIBUTES) {
+        const value = viewImage.getAttribute(attribute);
+        if (value && conversionApi.schema.checkAttribute(modelImage, attribute)) {
+          conversionApi.writer.setAttribute(attribute, value, modelImage);
+        }
+      }
+    };
+
+    // Inline images: <img> converts directly to imageInline.
+    dispatcher.on('element:img', (evt, data, conversionApi) => {
+      copySizeAttributes(data, conversionApi, data.viewItem);
+    }, { priority: 'low' });
+
+    // Block images: <figure class="image"><img ...></figure> converts to
+    // imageBlock on the figure event; the img child carries the size.
+    dispatcher.on('element:figure', (evt, data, conversionApi) => {
+      copySizeAttributes(data, conversionApi, findViewImage(data.viewItem));
+    }, { priority: 'low' });
+  });
+
+  editor.conversion.for('downcast').add(dispatcher => {
+    for (const attribute of SIZE_ATTRIBUTES) {
+      for (const model of IMAGE_MODELS) {
+        dispatcher.on(`attribute:${attribute}:${model}`, (evt, data, conversionApi) => {
+          if (!conversionApi.consumable.consume(data.item, evt.name)) return;
+
+          const viewElement = conversionApi.mapper.toViewElement(data.item);
+          if (!viewElement) return;
+
+          // For block images the mapped view element is the <figure>; the
+          // attribute belongs on the <img> inside it.
+          const viewImage = viewElement.is('element', 'img')
+            ? viewElement
+            : findViewImage(viewElement);
+          if (!viewImage) return;
+
+          if (data.attributeNewValue !== null && data.attributeNewValue !== undefined) {
+            conversionApi.writer.setAttribute(attribute, data.attributeNewValue, viewImage);
+          } else {
+            conversionApi.writer.removeAttribute(attribute, viewImage);
+          }
+        });
+      }
+    }
+  });
+}
+
+function findViewImage(viewElement) {
+  for (const child of viewElement.getChildren()) {
+    if (child.is && child.is('element', 'img')) {
+      return child;
+    }
+    if (child.is && child.is('element')) {
+      const nested = findViewImage(child);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+/**
+ * Toolbar limited to features that actually exist in the classic build.
+ * (The previous configuration listed plugins that are not bundled, which
+ * produced console warnings and buttons that never appeared.)
+ */
+export const EDITOR_TOOLBAR = [
+  'heading',
+  '|',
+  'bold', 'italic',
+  '|',
+  'link', 'bulletedList', 'numberedList',
+  '|',
+  'outdent', 'indent',
+  '|',
+  'imageUpload', 'blockQuote', 'insertTable', 'mediaEmbed',
+  '|',
+  'undo', 'redo'
+];
+
+export const EDITOR_IMAGE_CONFIG = {
+  toolbar: [
+    'imageStyle:alignLeft',
+    'imageStyle:alignCenter',
+    'imageStyle:alignRight',
+    'imageStyle:side',
+    '|',
+    'toggleImageCaption',
+    'imageTextAlternative'
+  ]
+};
+
+export const EDITOR_TABLE_CONFIG = {
+  contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells']
+};


### PR DESCRIPTION
AI integration:
- New AIService supporting OpenAI, Google Gemini and Anthropic Claude with
  user-supplied API keys stored locally; JSON action protocol lets the model
  rewrite the article, insert HTML, replace the selection or set the title
- AI chat panel docked in the post editor with quick-action buttons
- Floating AI menu over selected text (improve, fix grammar, shorten,
  expand, free-form instruction) that rewrites the fragment in place
- AI settings section (provider, key, model, test connection) with i18n
  strings in en-US and pt-PT

Editor and UI fixes:
- Toolbar trimmed to features that exist in the CKEditor classic build
  (previous config listed unavailable plugins)
- Image upload now works via a base64 upload adapter
- Image width/height attributes survive editing (runtime schema extension
  and converters), enabling AI and manual image sizing/positioning
- Offer to restore auto-saved local drafts on new posts
- Apply default blog and default template from Settings in the editor
- Word/character count status bar
- Reject binary .docx imports with a clear message instead of inserting
  garbage; wrap imported TXT lines in paragraphs
- Fix server.js crash when no browser opener is available (headless)

Docs and tests:
- README.md / README_PT.md: AI assistant setup and usage sections
- Project_Structure.md rewritten to match the actual codebase and roadmap
- AIService unit tests (settings, action protocol parsing, sanitization,
  all three provider transports); bump version to 1.1.0

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WH4nTgGnsbhd2H327V6fE6