### PR TITLE
Allow triggering the release workflow manually with a tag input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to create (e.g. v1.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,10 +24,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: |
           gh release view "$TAG_NAME" >/dev/null 2>&1 || \
           gh release create "$TAG_NAME" \
+            --target "$GITHUB_SHA" \
             --title "BlogCraft $TAG_NAME" \
             --notes "Portable BlogCraft binaries — no installation or dependencies required. Run the file for your operating system; BlogCraft starts locally and opens the browser automatically. The Android APK is an experimental preview: enable \"install from unknown sources\" to sideload it."
 
@@ -50,7 +57,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: |
           $asset = Get-ChildItem dist -Filter *.exe | Select-Object -First 1
           gh release upload "$env:TAG_NAME" "$($asset.FullName)" --clobber
@@ -83,7 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: gh release upload "$TAG_NAME" dist/blogcraft-*-linux-x64 --clobber
 
   macos:
@@ -119,7 +126,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: gh release upload "$TAG_NAME" dist/blogcraft-*-macos-* --clobber
 
   android:
@@ -187,5 +194,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: gh release upload "$TAG_NAME" "$APK_NAME" --clobber


### PR DESCRIPTION
## Summary

Small follow-up to #29 (this commit was pushed moments before that merge and missed it): adds a `workflow_dispatch` trigger to the release workflow with a `tag` input. `gh release create` creates the tag server-side, so releases can be launched manually from the Actions tab (or API) in addition to tag pushes.

- `TAG_NAME` now resolves to `inputs.tag || github.ref_name`, so both trigger paths work
- `gh release create` passes `--target "$GITHUB_SHA"` so a dispatched release tags the exact commit the workflow ran on

## Test plan
- [x] YAML validated
- [ ] Will be exercised immediately by dispatching the v1.1.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WH4nTgGnsbhd2H327V6fE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH4nTgGnsbhd2H327V6fE6)_