### PR TITLE
Fix editor collapsing on first click and field overflow with AI panel

### DIFF
--- a/src/components/PostEditor.js
+++ b/src/components/PostEditor.js
@@ -974,9 +974,10 @@ function PostEditor({ theme, toggleTheme }) {
                 // Armazenar referência ao editor
                 editorRef.current = editor;
                 setEditorInstance(editor);
-
-                // Configurações adicionais
-                editor.ui.view.editable.element.style.minHeight = '500px';
+                // A altura mínima do editor é definida em CSS
+                // (.rich-editor .ck-editor__editable_inline); defini-la aqui
+                // via style inline não funciona porque o CKEditor limpa o
+                // atributo style do editável quando este recebe foco.
               }}
               config={{
                 // Plugins adicionais: upload de imagens (base64) e

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -111,7 +111,11 @@
 
   .editor-content .post-actions {
     display: grid;
-    grid-template-columns: repeat(4, minmax(180px, 1fr));
+    /* auto-fit reflows by the real container width, so the fields stay
+       aligned whether or not the AI panel is open (a fixed column count
+       plus viewport media queries overflowed once the panel narrowed the
+       editor column without changing the viewport width). */
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
     gap: 16px;
     margin-bottom: 20px;
     align-items: end;
@@ -297,6 +301,14 @@
     border: 1px solid;
     box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
   }
+
+  /* Keep a comfortable editing height. This must live in CSS: CKEditor
+     manages the editable element's inline `style` attribute and wipes any
+     inline min-height we set from JS the moment the editor gains focus,
+     which otherwise collapses the box to a single line on first click. */
+  .rich-editor .ck-editor__editable_inline {
+    min-height: 500px;
+  }
   
   .light .rich-editor {
     border-color: var(--border-light);
@@ -438,12 +450,6 @@
     color: #d4edda;
   }
   
-  @media (max-width: 1180px) {
-    .editor-content .post-actions {
-      grid-template-columns: repeat(2, minmax(220px, 1fr));
-    }
-  }
-
   /* Responsividade */
   @media (max-width: 768px) {
     .editor-content {


### PR DESCRIPTION
## Summary

Fixes two editor UI bugs reported on a new post:

1. **The text box collapsed to a single line on first click.** The editor's `min-height: 500px` was applied as an inline style in `onReady`, but CKEditor manages the editable element's `style` attribute itself and wipes it when the element gains focus — so the first click reset the height. Reproduced with a headless measurement: `clientHeight` 498px before click → 53px after. Moved `min-height` to CSS (`.rich-editor .ck-editor__editable_inline`), which CKEditor does not overwrite. After the fix the height stays 498px through focus.

2. **The fields above the editor overflowed the card when the AI panel was open.** `.post-actions` used a fixed `repeat(4, minmax(180px, 1fr))` grid with viewport-based media queries. Opening the AI panel narrows the editor column without changing the viewport, so the 4-column grid no longer fit and spilled past the card (the "Tags" label leaked into the margin). Switched to `repeat(auto-fit, minmax(190px, 1fr))` so the fields reflow by the real container width, and removed the now-redundant 1180px breakpoint.

## Test plan
- [x] Headless repro confirms editable height survives focus (498px → 498px)
- [x] Fields reflow cleanly into the card with the AI panel open (verified via screenshot at 1400px)
- [x] `npm test` — 23 tests passing
- [x] Full end-to-end browser check green (editor, AI chat, selection menu, settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WH4nTgGnsbhd2H327V6fE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH4nTgGnsbhd2H327V6fE6)_